### PR TITLE
add JEPA_region training, inference

### DIFF
--- a/JEPA_region/configs/base.yaml
+++ b/JEPA_region/configs/base.yaml
@@ -1,0 +1,102 @@
+seed: 42
+
+run:
+  save_dir: /mimer/NOBACKUP/groups/naiss2025-5-243/youya/CodeRepair_JEPA_region/checkpoints
+  run_name: region_jepa
+
+data:
+  source: hf
+  hf:
+    dataset_id: "ASSERT-KTH/RunBugRun-Final"
+    split: "train"
+    fields:
+      buggy: "buggy_code"
+      fixed: "fixed_code"
+
+  indices:
+    global_target_dir: "/mimer/NOBACKUP/groups/naiss2025-5-243/Embeddings_RBR/Decoder_RBR/saved_indices"
+    split_dir: "/mimer/NOBACKUP/groups/naiss2025-5-243/Embeddings_RBR/Decoder_RBR/subset_indices"
+    global_target: "global_target_indices.npy"
+    train: "train_idx.npy"
+    val: "val_idx.npy"
+    test: "test_idx.npy"
+
+  num_workers: 4
+
+encoder:
+  name: "answerdotai/ModernBERT-large"
+  max_len: 512
+  train_mode: "frozen"
+  lora:
+    enabled: false
+    r: 16
+    alpha: 32
+    dropout: 0.05
+    bias: "none"
+    target_modules: []
+
+predictor:
+  layers: 4
+  heads: 8
+  mlp_ratio: 4.0
+  dropout: 0.1
+  use_residual: true
+  residual_scale: 1.0
+
+ema:
+  tau: 0.996
+
+loss:
+  supervision_target: "change_region"   # change_region / change_plus_shared / full_sequence
+  shared_weight: 0.1
+  w_align: 1.0
+  w_var: 1.0
+  w_cov: 0.0
+  align_eps: 1e-8
+  var_target_std: 1.0
+  var_eps: 1e-4
+
+train:
+  epochs: 3
+  batch_size: 8
+  grad_accum: 1
+  fp16: true
+  lr: 2e-5
+  lr_encoder: 1e-5
+  lr_predictor: 1e-4
+  weight_decay: 0.01
+  log_every: 50
+  eval_every_steps: 500
+  save_every_steps: 2000
+  save_every_epoch: false
+  resume_from: ""
+  resume_restore_rng: false
+
+infer:
+  ckpt_path: ""
+  save_path: "./infer_outputs"
+  splits: ["train", "val", "test"]
+  split: "test"
+  indices_file: ""
+  indices_file_by_split: {}
+  batch_size: 8
+  save_dtype: "float16"
+  max_items: -1
+
+optim:
+  betas: [0.9, 0.999]
+  eps: 1e-8
+
+ddp:
+  enabled: true
+  backend: "nccl"
+  find_unused_parameters: false
+
+wandb:
+  enabled: false
+  entity: ""
+  project: "CodeRepair_JEPA_region"
+  group: "encoder"
+  run_name: ""
+  id: ""
+  resume: "never"

--- a/JEPA_region/scripts/infer_region.sh
+++ b/JEPA_region/scripts/infer_region.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#SBATCH -A NAISS2026-3-261
+#SBATCH -p alvis
+#SBATCH -N 1
+#SBATCH --gpus-per-node=A100:4
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=8
+#SBATCH -t 06:00:00
+#SBATCH -J infer_last_change_region
+#SBATCH -o logs/encoder/%x_%A.out
+#SBATCH -e logs/encoder/%x_%A.err
+
+set -euo pipefail
+
+WORKDIR="/mimer/NOBACKUP/groups/naiss2025-5-243/Embeddings_RBR/Decoder_RBR/JEPA_region"
+SIF="/mimer/NOBACKUP/groups/naiss2025-5-243/Embeddings_RBR/Decoder_RBR/decoder_rbr.sif"
+PYDEPS="/mimer/NOBACKUP/groups/naiss2025-5-243/Embeddings_RBR/Decoder_RBR/pydeps"
+PY_FILE="${WORKDIR}/src/infer.py"
+EXP_CONFIG="${WORKDIR}/configs/base.yaml"
+
+SEQ_MODE="change_region"
+CKPT_PATH="/mimer/NOBACKUP/groups/naiss2025-5-243/youya/CodeRepair_JEPA_region/checkpoints/YOUR_CHANGE_REGION_RUN/checkpoints/ckpt_last.pt"
+RUN_NAME="change_region_pooled_last"
+OUT_BASE="/mimer/NOBACKUP/groups/naiss2025-5-243/youya/CodeRepair_JEPA_region/pooled_embeddings"
+SAVE_PATH="${OUT_BASE}/${RUN_NAME}"
+
+GLOBAL_TARGET_DIR="/mimer/NOBACKUP/groups/naiss2025-5-243/Embeddings_RBR/Decoder_RBR/saved_indices"
+SPLIT_DIR="/mimer/NOBACKUP/groups/naiss2025-5-243/Embeddings_RBR/Decoder_RBR/subset_indices"
+TRAIN_INDICES="train_idx.npy"
+VAL_INDICES="val_idx.npy"
+TEST_INDICES="test_idx.npy"
+
+HF_HOME="/mimer/NOBACKUP/groups/naiss2025-5-243/hf_cache"
+TRANSFORMERS_CACHE="${HF_HOME}/transformers"
+HF_DATASETS_CACHE="${HF_HOME}/datasets"
+mkdir -p "${TRANSFORMERS_CACHE}" "${HF_DATASETS_CACHE}"
+
+INFER_BATCH_SIZE=32
+SAVE_DTYPE="float16"
+MAX_ITEMS=-1
+NPROC=4
+
+export TOKENIZERS_PARALLELISM=false
+export PYTHONUNBUFFERED=1
+export NCCL_DEBUG=warn
+export NCCL_ASYNC_ERROR_HANDLING=1
+export PYTHONNOUSERSITE=1
+
+mkdir -p "${WORKDIR}/logs/encoder" "${OUT_BASE}"
+cd "${WORKDIR}"
+
+MASTER_ADDR=$(hostname)
+MASTER_PORT=$((15000 + RANDOM % 20000))
+export MASTER_ADDR MASTER_PORT
+
+echo "[Info] SEQ_MODE=${SEQ_MODE}"
+echo "[Info] CKPT_PATH=${CKPT_PATH}"
+echo "[Info] SAVE_PATH=${SAVE_PATH}"
+echo "[Info] GLOBAL_TARGET_DIR=${GLOBAL_TARGET_DIR}"
+echo "[Info] SPLIT_DIR=${SPLIT_DIR}"
+echo "[Info] TRAIN_INDICES=${TRAIN_INDICES} VAL_INDICES=${VAL_INDICES} TEST_INDICES=${TEST_INDICES}"
+echo "[Info] INFER_BATCH_SIZE=${INFER_BATCH_SIZE} SAVE_DTYPE=${SAVE_DTYPE} MAX_ITEMS=${MAX_ITEMS}"
+echo "[Info] NodeList=${SLURM_NODELIST:-NA} GPUS_ON_NODE=${SLURM_GPUS_ON_NODE:-NA}"
+
+srun -N 1 -n 1 --ntasks-per-node=1 --kill-on-bad-exit=1 \
+  apptainer exec --cleanenv --nv \
+    --env CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-}" \
+    --env MASTER_ADDR="${MASTER_ADDR}" \
+    --env MASTER_PORT="${MASTER_PORT}" \
+    --env TOKENIZERS_PARALLELISM=false \
+    --env NCCL_ASYNC_ERROR_HANDLING=1 \
+    --env NCCL_DEBUG=warn \
+    --env PYTHONUNBUFFERED=1 \
+    --env PYTHONPATH="${PYDEPS}:${PYTHONPATH:-}" \
+    --env TORCHDYNAMO_DISABLE=1 \
+    --env TORCHINDUCTOR_DISABLE=1 \
+    --env TORCH_COMPILE_DISABLE=1 \
+    --bind "${WORKDIR}:${WORKDIR}" \
+    --bind "${HF_HOME}:${HF_HOME}" \
+    --bind "${PYDEPS}:${PYDEPS}" \
+    "${SIF}" bash -lc "
+      set -euo pipefail
+      cd '${WORKDIR}'
+      echo \"[in-container] host=\$(hostname) CVD=\${CUDA_VISIBLE_DEVICES:-}\"
+
+      python -m torch.distributed.run \
+        --nnodes=1 \
+        --nproc_per_node=${NPROC} \
+        --rdzv_backend=c10d \
+        --rdzv_endpoint=\$MASTER_ADDR:\$MASTER_PORT \
+        '${PY_FILE}' \
+          --config '${EXP_CONFIG}' \
+          --set data.indices.global_target_dir='${GLOBAL_TARGET_DIR}' \
+          --set data.indices.split_dir='${SPLIT_DIR}' \
+          --set infer.ckpt_path='${CKPT_PATH}' \
+          --set infer.save_path='${SAVE_PATH}' \
+          --set infer.splits=[train,val,test] \
+          --set infer.indices_file_by_split.train='${TRAIN_INDICES}' \
+          --set infer.indices_file_by_split.val='${VAL_INDICES}' \
+          --set infer.indices_file_by_split.test='${TEST_INDICES}' \
+          --set infer.batch_size=${INFER_BATCH_SIZE} \
+          --set infer.save_dtype='${SAVE_DTYPE}' \
+          --set infer.max_items=${MAX_ITEMS} \
+          --set ddp.enabled=true \
+          --set data.num_workers=8
+    "
+
+echo "DONE"

--- a/JEPA_region/scripts/train_region_lora_sweep.sh
+++ b/JEPA_region/scripts/train_region_lora_sweep.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+#SBATCH -A naiss2025-5-243
+#SBATCH -p alvis
+#SBATCH -N 1
+#SBATCH --gpus-per-node=A100:4
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=8
+#SBATCH -t 06:00:00
+#SBATCH -J region_lora_sweep
+#SBATCH --array=0-11
+#SBATCH -o logs/encoder/%x_%A_%a.out
+#SBATCH -e logs/encoder/%x_%A_%a.err
+
+set -euo pipefail
+
+# -------------------------
+# Paths
+# -------------------------
+WORKDIR="/mimer/NOBACKUP/groups/naiss2025-5-243/Embeddings_RBR/Decoder_RBR/JEPA_region"
+SIF="/mimer/NOBACKUP/groups/naiss2025-5-243/Embeddings_RBR/Decoder_RBR/decoder_rbr.sif"
+
+PY_FILE="${WORKDIR}/src/train.py"
+EXP_CONFIG="${WORKDIR}/configs/base.yaml"
+
+OUT_BASE="/mimer/NOBACKUP/groups/naiss2025-5-243/youya/CodeRepair_JEPA_region/checkpoints"
+PYDEPS="/mimer/NOBACKUP/groups/naiss2025-5-243/Embeddings_RBR/Decoder_RBR/pydeps"
+
+# -------------------------
+# Indices
+# -------------------------
+GLOBAL_TARGET_DIR="/mimer/NOBACKUP/groups/naiss2025-5-243/Embeddings_RBR/Decoder_RBR/saved_indices"
+SPLIT_DIR="/mimer/NOBACKUP/groups/naiss2025-5-243/Embeddings_RBR/Decoder_RBR/subset_indices"
+
+# -------------------------
+# W&B
+# -------------------------
+export WANDB_MODE="online"
+export WANDB_ENTITY="assert-kth"
+export WANDB_PROJECT="CodeRepair_JEPA_region"
+export WANDB_GROUP="encoder_region_lora"
+export WANDB_RESUME="never"
+
+# -------------------------
+# HF cache
+# -------------------------
+export HF_HOME="/mimer/NOBACKUP/groups/naiss2025-5-243/hf_cache"
+export TRANSFORMERS_CACHE="$HF_HOME/transformers"
+export HF_DATASETS_CACHE="$HF_HOME/datasets"
+mkdir -p "$TRANSFORMERS_CACHE" "$HF_DATASETS_CACHE"
+
+# -------------------------
+# Runtime env
+# -------------------------
+export TOKENIZERS_PARALLELISM=false
+export PYTHONUNBUFFERED=1
+export NCCL_DEBUG=warn
+export NCCL_ASYNC_ERROR_HANDLING=1
+export PYTHONNOUSERSITE=1
+
+mkdir -p "${WORKDIR}/logs/encoder" "${OUT_BASE}"
+cd "${WORKDIR}"
+
+# -------------------------
+# Sweep: 2 LR sets x 2 predictor LRs x 3 w_cov = 12 jobs
+# -------------------------
+LR_E_SET=(1e-5 2e-5)
+LR_P_SET=(5e-5 1e-4)
+W_COV_SET=(0.0 0.01 0.1)
+
+TASK_ID=${SLURM_ARRAY_TASK_ID}
+
+N_P=${#LR_P_SET[@]}
+N_C=${#W_COV_SET[@]}
+BLOCK=$((N_P * N_C))
+
+LR_E_IDX=$(( TASK_ID / BLOCK ))
+REM=$(( TASK_ID % BLOCK ))
+LR_P_IDX=$(( REM / N_C ))
+W_COV_IDX=$(( REM % N_C ))
+
+LR_E=${LR_E_SET[$LR_E_IDX]}
+LR_P=${LR_P_SET[$LR_P_IDX]}
+W_COV=${W_COV_SET[$W_COV_IDX]}
+
+# LoRA defaults for the first sweep
+LORA_R=32
+LORA_ALPHA=$((2 * LORA_R))
+LORA_DROPOUT=0.05
+TAU=0.996
+
+# Predictor / supervision setup
+SUPERVISION_TARGET="change_region"   # change_region / change_plus_shared / full_sequence
+SHARED_WEIGHT=0.1
+USE_RESIDUAL=true                    # true / false
+RESIDUAL_SCALE=1.0
+
+# Training defaults for the first sweep
+BATCH_SIZE=4
+GRAD_ACCUM=2
+EPOCHS=1
+RESUME_CKPT=""
+
+RES_TAG="residual"
+if [ "${USE_RESIDUAL}" = "false" ]; then
+  RES_TAG="no_residual"
+fi
+RUN_NAME="region_${SUPERVISION_TARGET}_lrE${LR_E}_lrP${LR_P}_wcov${W_COV}_r${LORA_R}_${RES_TAG}"
+if [ "${SUPERVISION_TARGET}" = "change_plus_shared" ]; then
+  RUN_NAME="${RUN_NAME}_wshared${SHARED_WEIGHT}"
+fi
+
+echo "[Info] TASK_ID=${TASK_ID}"
+echo "[Info] LR_E=${LR_E} LR_P=${LR_P} W_COV=${W_COV}"
+echo "[Info] LORA_R=${LORA_R} LORA_ALPHA=${LORA_ALPHA} TAU=${TAU}"
+echo "[Info] SUPERVISION_TARGET=${SUPERVISION_TARGET} SHARED_WEIGHT=${SHARED_WEIGHT} USE_RESIDUAL=${USE_RESIDUAL} RESIDUAL_SCALE=${RESIDUAL_SCALE}"
+echo "[Info] BATCH_SIZE=${BATCH_SIZE} GRAD_ACCUM=${GRAD_ACCUM} EPOCHS=${EPOCHS}"
+echo "[Info] RESUME_CKPT=${RESUME_CKPT:-NONE}"
+echo "[Info] GLOBAL_TARGET_DIR=${GLOBAL_TARGET_DIR}"
+echo "[Info] SPLIT_DIR=${SPLIT_DIR}"
+echo "[Info] RUN_NAME=${RUN_NAME}"
+echo "[Info] SAVE_ROOT=${OUT_BASE}"
+echo "[Info] NodeList=${SLURM_NODELIST:-NA} GPUS_ON_NODE=${SLURM_GPUS_ON_NODE:-NA}"
+echo "[Info] CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-NA}"
+
+# -------------------------
+# torchrun rendezvous
+# -------------------------
+MASTER_ADDR=$(hostname)
+MASTER_PORT=$((15000 + RANDOM % 20000))
+export MASTER_ADDR MASTER_PORT
+NPROC=${SLURM_GPUS_ON_NODE:-1}
+
+# -------------------------
+# Main run
+# -------------------------
+srun -N 1 -n 1 --ntasks-per-node=1 --kill-on-bad-exit=1 \
+  apptainer exec --cleanenv --nv \
+    --env CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-}" \
+    --env MASTER_ADDR="$MASTER_ADDR" \
+    --env MASTER_PORT="$MASTER_PORT" \
+    --env TOKENIZERS_PARALLELISM=false \
+    --env NCCL_ASYNC_ERROR_HANDLING=1 \
+    --env NCCL_DEBUG=warn \
+    --env PYTHONUNBUFFERED=1 \
+    --env WANDB_MODE="${WANDB_MODE}" \
+    --env WANDB_ENTITY="${WANDB_ENTITY}" \
+    --env WANDB_PROJECT="${WANDB_PROJECT}" \
+    --env WANDB_GROUP="${WANDB_GROUP}" \
+    --env WANDB_RESUME="${WANDB_RESUME}" \
+    --env PYTHONPATH="${PYDEPS}:${PYTHONPATH:-}" \
+    --env TORCHDYNAMO_DISABLE=1 \
+    --env TORCHINDUCTOR_DISABLE=1 \
+    --env TORCH_COMPILE_DISABLE=1 \
+    --bind "${WORKDIR}:${WORKDIR}" \
+    --bind "${HF_HOME}:${HF_HOME}" \
+    --bind "${PYDEPS}:${PYDEPS}" \
+    "$SIF" bash -lc "
+      set -euo pipefail
+      cd '${WORKDIR}'
+      echo \"[in-container] host=\$(hostname) CVD=\${CUDA_VISIBLE_DEVICES:-}\"
+
+      python -m torch.distributed.run \
+        --nnodes=1 \
+        --nproc_per_node=${NPROC} \
+        --rdzv_backend=c10d \
+        --rdzv_endpoint=\$MASTER_ADDR:\$MASTER_PORT \
+        '${PY_FILE}' \
+          --config '${EXP_CONFIG}' \
+          --set run.save_dir='${OUT_BASE}' \
+          --set run.run_name='${RUN_NAME}' \
+          --set data.indices.global_target_dir='${GLOBAL_TARGET_DIR}' \
+          --set data.indices.split_dir='${SPLIT_DIR}' \
+          --set wandb.enabled=true \
+          --set wandb.entity='${WANDB_ENTITY}' \
+          --set wandb.project='${WANDB_PROJECT}' \
+          --set wandb.group='${WANDB_GROUP}' \
+          --set wandb.run_name='${RUN_NAME}' \
+          --set wandb.id='' \
+          --set wandb.resume='${WANDB_RESUME}' \
+          --set encoder.train_mode=lora \
+          --set encoder.lora.enabled=true \
+          --set encoder.lora.r=${LORA_R} \
+          --set encoder.lora.alpha=${LORA_ALPHA} \
+          --set encoder.lora.dropout=${LORA_DROPOUT} \
+          --set encoder.lora.target_modules=[Wqkv,Wo] \
+          --set predictor.use_residual=${USE_RESIDUAL} \
+          --set predictor.residual_scale=${RESIDUAL_SCALE} \
+          --set train.batch_size=${BATCH_SIZE} \
+          --set train.grad_accum=${GRAD_ACCUM} \
+          --set train.epochs=${EPOCHS} \
+          --set train.lr_encoder=${LR_E} \
+          --set train.lr_predictor=${LR_P} \
+          --set train.resume_from='${RESUME_CKPT}' \
+          --set loss.supervision_target='${SUPERVISION_TARGET}' \
+          --set loss.shared_weight=${SHARED_WEIGHT} \
+          --set loss.w_align=1.0 \
+          --set loss.w_var=1.0 \
+          --set loss.w_cov=${W_COV} \
+          --set ema.tau=${TAU} \
+          --set train.eval_every_steps=800 \
+          --set train.save_every_steps=2000 \
+          --set data.num_workers=8
+    "
+
+echo "DONE"

--- a/JEPA_region/src/infer.py
+++ b/JEPA_region/src/infer.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Any, Dict, List
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler
+
+from datasets import load_dataset
+from tqdm import tqdm
+from transformers import AutoTokenizer
+
+from models import build_encoder, build_predictor, load_encoder_tunable_state
+from utils import (
+    apply_overrides,
+    ddp_barrier,
+    ddp_cleanup,
+    ddp_enabled,
+    ddp_local_rank,
+    ddp_setup,
+    deep_update,
+    is_main,
+    load_yaml,
+    masked_mean_pool,
+    rank,
+    save_json,
+)
+
+
+def resolve_config(exp_config_path: str, overrides: List[str]) -> Dict[str, Any]:
+    base_path = os.path.join(os.path.dirname(exp_config_path), "base.yaml")
+    base_cfg = load_yaml(base_path)
+    exp_cfg = load_yaml(exp_config_path)
+    cfg = deep_update(base_cfg, exp_cfg)
+    cfg = apply_overrides(cfg, overrides)
+    return cfg
+
+
+def flatten_overrides(raw_overrides: List[Any]) -> List[str]:
+    flat: List[str] = []
+    for item in raw_overrides:
+        if isinstance(item, (list, tuple)):
+            flat.extend(str(x) for x in item)
+        else:
+            flat.append(str(item))
+    return flat
+
+
+def load_indices(indices_dir: str, filename: str) -> np.ndarray:
+    return np.load(os.path.join(indices_dir, filename))
+
+
+def to_device(batch: Dict[str, torch.Tensor], device: torch.device) -> Dict[str, torch.Tensor]:
+    return {k: v.to(device, non_blocking=True) for k, v in batch.items()}
+
+
+def save_pt(obj: Any, path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    torch.save(obj, path)
+
+
+def load_pt(path: str) -> Any:
+    return torch.load(path, map_location="cpu", weights_only=False)
+
+
+def resolve_indices_filename(idx_cfg: Dict[str, Any], infer_cfg: Dict[str, Any], split: str) -> str:
+    indices_map = infer_cfg.get("indices_file_by_split", {})
+    if isinstance(indices_map, dict) and indices_map.get(split):
+        return str(indices_map[split])
+    if infer_cfg.get("indices_file"):
+        return str(infer_cfg["indices_file"])
+
+    split = str(split).lower()
+    if split == "train":
+        return str(idx_cfg.get("train", "train_idx.npy"))
+    if split == "val":
+        return str(idx_cfg.get("val", "val_idx.npy"))
+    if split == "test":
+        return str(idx_cfg.get("test", "test_idx.npy"))
+    raise ValueError(f"Unknown infer.split='{split}'")
+
+
+def _normalize_dtype_tensor(x: torch.Tensor, save_dtype: str) -> torch.Tensor:
+    if save_dtype == "float16":
+        return x.half()
+    if save_dtype == "bfloat16":
+        return x.bfloat16()
+    return x.float()
+
+
+def _sort_payload_by_indices(payload: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    gidx = payload["global_indices"]
+    order = torch.argsort(gidx)
+    return {
+        "emb": payload["emb"][order],
+        "global_indices": gidx[order],
+    }
+
+
+def try_merge_on_rank0(split_dir: str, world: int, file_names: List[str]) -> None:
+    if not is_main():
+        return
+
+    def merge(file_name: str) -> None:
+        parts = []
+        for r in range(world):
+            path = os.path.join(split_dir, f"{file_name}.rank{r}.pt")
+            if not os.path.exists(path):
+                print(f"[Merge] missing shard: {path}")
+                return
+            parts.append(load_pt(path))
+
+        payload = {
+            "emb": torch.cat([part["emb"] for part in parts], dim=0),
+            "global_indices": torch.cat([part["global_indices"] for part in parts], dim=0),
+        }
+        payload = _sort_payload_by_indices(payload)
+        torch.save(payload, os.path.join(split_dir, f"{file_name}.pt"))
+        print(f"[Merge] wrote: {os.path.join(split_dir, f'{file_name}.pt')}")
+
+    for file_name in file_names:
+        merge(file_name)
+
+
+def merge_runtime_with_checkpoint_cfg(runtime_cfg: Dict[str, Any], ckpt_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    cfg = deep_update({}, ckpt_cfg)
+    for key in ["infer", "ddp"]:
+        if key in runtime_cfg:
+            cfg[key] = deep_update(cfg.get(key, {}), runtime_cfg[key])
+    if "data" in runtime_cfg:
+        cfg["data"] = deep_update(cfg.get("data", {}), runtime_cfg["data"])
+    return cfg
+
+
+@torch.no_grad()
+def run_infer(cfg: Dict[str, Any]) -> None:
+    infer_cfg = cfg.get("infer", {})
+    ckpt_path = str(infer_cfg.get("ckpt_path", ""))
+    if not ckpt_path:
+        raise ValueError("infer.ckpt_path must be set.")
+
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    ckpt_cfg = ckpt.get("cfg")
+    if isinstance(ckpt_cfg, dict):
+        cfg = merge_runtime_with_checkpoint_cfg(cfg, ckpt_cfg)
+        infer_cfg = cfg.get("infer", {})
+
+    use_ddp = bool(cfg.get("ddp", {}).get("enabled", False)) and ddp_enabled()
+    if use_ddp:
+        ddp_setup(cfg.get("ddp", {}).get("backend", "nccl"))
+
+    device = torch.device("cuda", ddp_local_rank()) if torch.cuda.is_available() else torch.device("cpu")
+    save_path = str(infer_cfg.get("save_path", "./infer_outputs"))
+    save_dtype = str(infer_cfg.get("save_dtype", "float16")).lower()
+    max_items = int(infer_cfg.get("max_items", -1))
+    os.makedirs(save_path, exist_ok=True)
+    split_list = infer_cfg.get("splits")
+    if split_list:
+        splits = [str(x).lower() for x in split_list]
+    else:
+        splits = [str(infer_cfg.get("split", "test")).lower()]
+
+    file_names = ["buggy_ctx", "fixed_ctx", "buggy_tgt", "fixed_tgt", "pred"]
+
+    tokenizer = AutoTokenizer.from_pretrained(cfg["encoder"]["name"], use_fast=True)
+
+    enc_ctx, hidden_dim = build_encoder(cfg, device=device)
+    enc_tgt, _ = build_encoder(cfg, device=device)
+    predictor = build_predictor(cfg, hidden_dim=hidden_dim, device=device)
+
+    if "enc_ctx" in ckpt:
+        enc_ctx.load_state_dict(ckpt["enc_ctx"], strict=True)
+    elif "enc_ctx_tunable" in ckpt:
+        load_encoder_tunable_state(enc_ctx, ckpt["enc_ctx_tunable"], strict=False)
+    else:
+        raise KeyError("Checkpoint is missing encoder context weights.")
+
+    if "enc_tgt" in ckpt:
+        enc_tgt.load_state_dict(ckpt["enc_tgt"], strict=True)
+    elif "enc_tgt_tunable" in ckpt:
+        load_encoder_tunable_state(enc_tgt, ckpt["enc_tgt_tunable"], strict=False)
+    elif "enc_ctx" in ckpt:
+        enc_tgt.load_state_dict(ckpt["enc_ctx"], strict=True)
+    elif "enc_ctx_tunable" in ckpt:
+        load_encoder_tunable_state(enc_tgt, ckpt["enc_ctx_tunable"], strict=False)
+    else:
+        raise KeyError("Checkpoint is missing encoder target weights.")
+
+    predictor.load_state_dict(ckpt["predictor"], strict=True)
+    for p in enc_tgt.parameters():
+        p.requires_grad = False
+    enc_ctx.eval()
+    enc_tgt.eval()
+    predictor.eval()
+
+    manifest = {
+        "splits": splits,
+        "files": file_names,
+        "format": {"emb_key": "emb", "global_indices_key": "global_indices"},
+        "save_dtype": save_dtype,
+        "checkpoint": os.path.abspath(ckpt_path),
+        "cfg_source": "checkpoint_cfg+runtime_infer_overrides" if isinstance(ckpt_cfg, dict) else "runtime_cfg",
+    }
+
+    for split in splits:
+        split_dir = os.path.join(save_path, split)
+        os.makedirs(split_dir, exist_ok=True)
+        dl, _ = build_dataloader(cfg, tokenizer, use_ddp, infer_cfg, split)
+
+        buffers = {name: [] for name in file_names}
+        gidx_all = []
+        total_saved = 0
+
+        iterator = tqdm(dl, desc=f"InferLast-{split}", dynamic_ncols=True) if is_main() else dl
+        for batch in iterator:
+            tok_buggy, tok_fixed, global_indices = batch
+            tok_buggy = to_device(tok_buggy, device)
+            tok_fixed = to_device(tok_fixed, device)
+
+            buggy_ctx_seq = enc_ctx(tok_buggy["input_ids"], tok_buggy["attention_mask"])
+            fixed_ctx_seq = enc_ctx(tok_fixed["input_ids"], tok_fixed["attention_mask"])
+            buggy_tgt_seq = enc_tgt(tok_buggy["input_ids"], tok_buggy["attention_mask"])
+            fixed_tgt_seq = enc_tgt(tok_fixed["input_ids"], tok_fixed["attention_mask"])
+            pred_seq = predictor(buggy_ctx_seq, attention_mask=tok_buggy["attention_mask"])
+
+            buggy_mask = tok_buggy["attention_mask"].bool()
+            fixed_mask = tok_fixed["attention_mask"].bool()
+
+            pooled = {
+                "buggy_ctx": masked_mean_pool(buggy_ctx_seq, buggy_mask),
+                "fixed_ctx": masked_mean_pool(fixed_ctx_seq, fixed_mask),
+                "buggy_tgt": masked_mean_pool(buggy_tgt_seq, buggy_mask),
+                "fixed_tgt": masked_mean_pool(fixed_tgt_seq, fixed_mask),
+                "pred": masked_mean_pool(pred_seq, buggy_mask),
+            }
+
+            if max_items > 0:
+                remaining = max_items - total_saved
+                if remaining <= 0:
+                    break
+                for key in pooled:
+                    pooled[key] = pooled[key][:remaining]
+                global_indices = global_indices[:remaining]
+
+            for key in pooled:
+                buffers[key].append(_normalize_dtype_tensor(pooled[key], save_dtype).cpu())
+            gidx_all.append(global_indices.cpu())
+            total_saved += int(global_indices.numel())
+
+        if not gidx_all:
+            raise RuntimeError(f"No samples were processed during inference for split='{split}'.")
+
+        global_indices_tensor = torch.cat(gidx_all, dim=0)
+        for key in file_names:
+            payload = {
+                "emb": torch.cat(buffers[key], dim=0),
+                "global_indices": global_indices_tensor,
+            }
+            payload = _sort_payload_by_indices(payload)
+            save_pt(payload, os.path.join(split_dir, f"{key}.rank{rank()}.pt"))
+
+        if use_ddp:
+            ddp_barrier()
+        try_merge_on_rank0(split_dir, world=int(os.environ.get("WORLD_SIZE", "1")), file_names=file_names)
+        if use_ddp:
+            ddp_barrier()
+
+    if is_main():
+        save_json(manifest, os.path.join(save_path, "manifest.json"))
+    if use_ddp:
+        ddp_cleanup()
+
+
+def build_dataloader(cfg: Dict[str, Any], tokenizer, use_ddp: bool, infer_cfg: Dict[str, Any], split: str):
+    assert cfg["data"]["source"] == "hf", "This infer script expects data.source=hf."
+    hf_cfg = cfg["data"]["hf"]
+    idx_cfg = cfg["data"]["indices"]
+
+    dataset_id = hf_cfg["dataset_id"]
+    split_name = hf_cfg.get("split", "train")
+    buggy_key = hf_cfg["fields"]["buggy"]
+    fixed_key = hf_cfg["fields"]["fixed"]
+    max_len = int(cfg["encoder"]["max_len"])
+
+    global_target_dir = idx_cfg["global_target_dir"]
+    split_dir = idx_cfg["split_dir"]
+    global_target = load_indices(global_target_dir, idx_cfg["global_target"])
+    idx_filename = resolve_indices_filename(idx_cfg, infer_cfg, split)
+    subset_idx = load_indices(split_dir, idx_filename)
+    global_indices_all = global_target[subset_idx]
+
+    ds_full = load_dataset(dataset_id, split=split_name)
+    ds_subset = ds_full.select(global_target.tolist())
+    ds_selected = ds_subset.select(subset_idx.tolist())
+
+    def collate_fn(batch):
+        buggy = [str(x.get(buggy_key, "") or "") for x in batch]
+        fixed = [str(x.get(fixed_key, "") or "") for x in batch]
+        indices = torch.tensor([int(x["_global_index"]) for x in batch], dtype=torch.long)
+        tok_buggy = tokenizer(
+            buggy,
+            padding=True,
+            truncation=True,
+            max_length=max_len,
+            return_tensors="pt",
+        )
+        tok_fixed = tokenizer(
+            fixed,
+            padding=True,
+            truncation=True,
+            max_length=max_len,
+            return_tensors="pt",
+        )
+        return tok_buggy, tok_fixed, indices
+
+    ds_selected = ds_selected.add_column("_global_index", global_indices_all.tolist())
+    sampler = DistributedSampler(ds_selected, shuffle=False) if use_ddp else None
+    dl = DataLoader(
+        ds_selected,
+        batch_size=int(infer_cfg.get("batch_size", cfg["train"]["batch_size"])),
+        shuffle=False,
+        sampler=sampler,
+        num_workers=int(cfg["data"].get("num_workers", 4)),
+        pin_memory=True,
+        collate_fn=collate_fn,
+        drop_last=False,
+    )
+    return dl, sampler
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, required=True)
+    parser.add_argument("--set", nargs="*", action="append", default=[])
+    args = parser.parse_args()
+
+    cfg = resolve_config(args.config, flatten_overrides(args.set))
+    run_infer(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/JEPA_region/src/losses.py
+++ b/JEPA_region/src/losses.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class CosineAlignLoss(nn.Module):
+    """Mean cosine alignment loss."""
+
+    def __init__(self, eps: float = 1e-8):
+        super().__init__()
+        self.eps = float(eps)
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        pred = F.normalize(pred, dim=-1, eps=self.eps)
+        target = F.normalize(target, dim=-1, eps=self.eps)
+        return 1.0 - (pred * target).sum(dim=-1).mean()
+
+
+class VarianceLoss(nn.Module):
+    """Variance regularizer on the predictor-side pooled region embeddings."""
+
+    def __init__(self, target_std: float = 1.0, eps: float = 1e-4):
+        super().__init__()
+        self.target_std = float(target_std)
+        self.eps = float(eps)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        std = torch.sqrt(x.var(dim=0, unbiased=False) + self.eps)
+        return F.relu(self.target_std - std).mean()
+
+
+class CovarianceLoss(nn.Module):
+    """Covariance regularizer on pooled region embeddings."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if x.dim() != 2:
+            raise ValueError(f"CovarianceLoss expects [B, D], got {tuple(x.shape)}")
+        batch_size, dim = x.shape
+        if batch_size <= 1:
+            return x.new_zeros(())
+
+        x = x - x.mean(dim=0, keepdim=True)
+        cov = (x.T @ x) / float(batch_size - 1)
+        off_diag = cov.flatten()[:-1].view(dim - 1, dim + 1)[:, 1:].flatten()
+        return off_diag.pow(2).sum() / float(dim)
+
+
+class RegionPoolLoss(nn.Module):
+    """
+    Region-pooled JEPA loss.
+
+    Inputs:
+      pred_region: [B, D]
+      tgt_region:  [B, D]
+    """
+
+    def __init__(
+        self,
+        w_align: float = 1.0,
+        w_var: float = 1.0,
+        w_cov: float = 0.0,
+        align_eps: float = 1e-8,
+        var_target_std: float = 1.0,
+        var_eps: float = 1e-4,
+    ):
+        super().__init__()
+        self.w_align = float(w_align)
+        self.w_var = float(w_var)
+        self.w_cov = float(w_cov)
+
+        self.align = CosineAlignLoss(eps=align_eps)
+        self.var = VarianceLoss(target_std=var_target_std, eps=var_eps)
+        self.cov = CovarianceLoss()
+
+    def forward(self, pred_region: torch.Tensor, tgt_region: torch.Tensor) -> Dict[str, torch.Tensor]:
+        l_align = self.align(pred_region, tgt_region)
+        l_var = self.var(pred_region)
+        l_cov = self.cov(pred_region)
+        loss = self.w_align * l_align + self.w_var * l_var + self.w_cov * l_cov
+        return {
+            "loss": loss,
+            "align": l_align,
+            "var": l_var,
+            "cov": l_cov,
+        }
+
+
+def build_loss(cfg: Dict[str, Any]) -> RegionPoolLoss:
+    lcfg = cfg.get("loss", {})
+    return RegionPoolLoss(
+        w_align=float(lcfg.get("w_align", 1.0)),
+        w_var=float(lcfg.get("w_var", 1.0)),
+        w_cov=float(lcfg.get("w_cov", 0.0)),
+        align_eps=float(lcfg.get("align_eps", 1e-8)),
+        var_target_std=float(lcfg.get("var_target_std", 1.0)),
+        var_eps=float(lcfg.get("var_eps", 1e-4)),
+    )

--- a/JEPA_region/src/models.py
+++ b/JEPA_region/src/models.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from transformers import AutoModel
+
+
+def infer_hidden_dim(model_name: str) -> int:
+    model = AutoModel.from_pretrained(model_name)
+    return int(getattr(model.config, "hidden_size"))
+
+
+def _freeze_module(module: nn.Module) -> None:
+    for param in module.parameters():
+        param.requires_grad = False
+
+
+def _unfreeze_module(module: nn.Module) -> None:
+    for param in module.parameters():
+        param.requires_grad = True
+
+
+def _named_trainable_params(module: nn.Module) -> Dict[str, torch.Tensor]:
+    return {
+        name: param.detach().to("cpu")
+        for name, param in module.named_parameters()
+        if param.requires_grad
+    }
+
+
+def _copy_named_params_into_module(
+    module: nn.Module,
+    saved: Dict[str, torch.Tensor],
+    strict: bool = False,
+) -> None:
+    current = dict(module.named_parameters())
+    missing = []
+    for name, tensor in saved.items():
+        if name in current:
+            current[name].data.copy_(tensor)
+        elif strict:
+            missing.append(name)
+    if strict and missing:
+        raise KeyError(f"Missing parameter names while loading: {missing[:20]}")
+
+
+def _apply_lora(backbone: nn.Module, lora_cfg: Dict[str, Any]) -> nn.Module:
+    try:
+        from peft import LoraConfig, get_peft_model
+    except Exception as e:  # pragma: no cover
+        raise RuntimeError(
+            "PEFT is required for LoRA encoder mode. Install it with `pip install peft`."
+        ) from e
+
+    target_modules = list(lora_cfg.get("target_modules", []))
+    if not target_modules:
+        raise ValueError("LoRA mode requires a non-empty encoder.lora.target_modules list.")
+
+    lora = LoraConfig(
+        r=int(lora_cfg.get("r", 16)),
+        lora_alpha=int(lora_cfg.get("alpha", 32)),
+        lora_dropout=float(lora_cfg.get("dropout", 0.05)),
+        target_modules=target_modules,
+        bias=str(lora_cfg.get("bias", "none")),
+    )
+    return get_peft_model(backbone, lora)
+
+
+class HFSequenceEncoder(nn.Module):
+    """
+    Hugging Face encoder wrapper.
+
+    Output:
+      hidden: [B, L, D]
+    """
+
+    def __init__(self, model_name: str):
+        super().__init__()
+        self.backbone = AutoModel.from_pretrained(model_name)
+
+    @property
+    def hidden_dim(self) -> int:
+        return int(getattr(self.backbone.config, "hidden_size"))
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        output = self.backbone(input_ids=input_ids, attention_mask=attention_mask)
+        return output.last_hidden_state
+
+
+class LightweightTransformerBlock(nn.Module):
+    """Pre-norm transformer block for sequence latent prediction."""
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        heads: int = 8,
+        mlp_ratio: float = 4.0,
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(hidden_dim)
+        self.attn = nn.MultiheadAttention(
+            embed_dim=hidden_dim,
+            num_heads=heads,
+            dropout=float(dropout),
+            batch_first=True,
+        )
+        self.dropout1 = nn.Dropout(float(dropout))
+
+        self.norm2 = nn.LayerNorm(hidden_dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(hidden_dim, int(hidden_dim * mlp_ratio)),
+            nn.GELU(),
+            nn.Dropout(float(dropout)),
+            nn.Linear(int(hidden_dim * mlp_ratio), hidden_dim),
+        )
+        self.dropout2 = nn.Dropout(float(dropout))
+
+    def forward(
+        self,
+        hidden: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        key_padding_mask = None
+        if attention_mask is not None:
+            key_padding_mask = attention_mask == 0
+
+        x = self.norm1(hidden)
+        attn_out, _ = self.attn(
+            x,
+            x,
+            x,
+            key_padding_mask=key_padding_mask,
+            need_weights=False,
+        )
+        hidden = hidden + self.dropout1(attn_out)
+
+        x = self.norm2(hidden)
+        mlp_out = self.mlp(x)
+        hidden = hidden + self.dropout2(mlp_out)
+        return hidden
+
+
+class SequencePredictor(nn.Module):
+    """
+    Lightweight sequence predictor.
+
+    Modes:
+      - direct:   z_pred = predictor(z_ctx)
+      - residual: z_pred = z_ctx + residual_scale * delta
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        layers: int = 4,
+        heads: int = 8,
+        mlp_ratio: float = 4.0,
+        dropout: float = 0.1,
+        use_residual: bool = True,
+        residual_scale: float = 1.0,
+    ):
+        super().__init__()
+        self.use_residual = bool(use_residual)
+        self.residual_scale = float(residual_scale)
+
+        self.blocks = nn.ModuleList(
+            [
+                LightweightTransformerBlock(
+                    hidden_dim=hidden_dim,
+                    heads=heads,
+                    mlp_ratio=mlp_ratio,
+                    dropout=dropout,
+                )
+                for _ in range(layers)
+            ]
+        )
+        self.final_norm = nn.LayerNorm(hidden_dim)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim)
+
+    def forward(
+        self,
+        hidden: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        x = hidden
+        for block in self.blocks:
+            x = block(x, attention_mask=attention_mask)
+        x = self.final_norm(x)
+        x = self.out_proj(x)
+
+        if self.use_residual:
+            return hidden + self.residual_scale * x
+        return x
+
+
+def build_encoder(cfg: Dict[str, Any], device: torch.device) -> Tuple[nn.Module, int]:
+    enc_cfg = cfg.get("encoder", {})
+    model_name = enc_cfg.get("name")
+    if not model_name:
+        raise ValueError("encoder.name must be set.")
+
+    encoder = HFSequenceEncoder(model_name=model_name).to(device)
+    hidden_dim = encoder.hidden_dim
+
+    train_mode = str(enc_cfg.get("train_mode", "frozen")).lower()
+    if train_mode not in {"frozen", "full", "lora"}:
+        raise ValueError(f"Unknown encoder.train_mode: {train_mode}")
+
+    if train_mode == "frozen":
+        _freeze_module(encoder)
+        encoder.eval()
+    elif train_mode == "full":
+        _unfreeze_module(encoder)
+        encoder.train()
+    else:
+        encoder.backbone = _apply_lora(encoder.backbone, enc_cfg.get("lora", {}))
+        _unfreeze_module(encoder)
+        encoder.train()
+
+    return encoder, hidden_dim
+
+
+def build_predictor(cfg: Dict[str, Any], hidden_dim: int, device: torch.device) -> nn.Module:
+    pred_cfg = cfg.get("predictor", {})
+    predictor = SequencePredictor(
+        hidden_dim=hidden_dim,
+        layers=int(pred_cfg.get("layers", 4)),
+        heads=int(pred_cfg.get("heads", 8)),
+        mlp_ratio=float(pred_cfg.get("mlp_ratio", 4.0)),
+        dropout=float(pred_cfg.get("dropout", 0.1)),
+        use_residual=bool(pred_cfg.get("use_residual", True)),
+        residual_scale=float(pred_cfg.get("residual_scale", 1.0)),
+    ).to(device)
+    return predictor
+
+
+def export_encoder_tunable_state(module: nn.Module) -> Dict[str, torch.Tensor]:
+    return _named_trainable_params(module)
+
+
+def load_encoder_tunable_state(
+    module: nn.Module,
+    state: Dict[str, torch.Tensor],
+    strict: bool = False,
+) -> None:
+    _copy_named_params_into_module(module, state, strict=strict)

--- a/JEPA_region/src/train.py
+++ b/JEPA_region/src/train.py
@@ -1,0 +1,798 @@
+from __future__ import annotations
+
+import argparse
+import os
+import random
+import time
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler
+
+from datasets import load_dataset
+from tqdm import tqdm
+from transformers import AutoTokenizer
+
+from losses import build_loss
+from models import build_encoder, build_predictor, export_encoder_tunable_state, load_encoder_tunable_state
+from utils import (
+    AverageMeter,
+    JSONLLogger,
+    apply_overrides,
+    ddp_all_reduce_sum,
+    ddp_cleanup,
+    ddp_enabled,
+    ddp_local_rank,
+    ddp_setup,
+    deep_update,
+    ema_update,
+    find_change_regions_in_batch,
+    is_main,
+    load_yaml,
+    pool_change_regions,
+    rank,
+    save_resolved_config,
+    seed_everything,
+    span_mask,
+    unwrap_ddp,
+)
+
+
+try:
+    import wandb  # type: ignore
+except Exception:
+    wandb = None
+
+
+def resolve_config(exp_config_path: str, overrides: List[str]) -> Dict[str, Any]:
+    base_path = os.path.join(os.path.dirname(exp_config_path), "base.yaml")
+    base_cfg = load_yaml(base_path)
+    exp_cfg = load_yaml(exp_config_path)
+    cfg = deep_update(base_cfg, exp_cfg)
+    cfg = apply_overrides(cfg, overrides)
+    return cfg
+
+
+def flatten_overrides(raw_overrides: List[Any]) -> List[str]:
+    flat: List[str] = []
+    for item in raw_overrides:
+        if isinstance(item, (list, tuple)):
+            flat.extend(str(x) for x in item)
+        else:
+            flat.append(str(item))
+    return flat
+
+
+def load_indices(indices_dir: str, filename: str) -> np.ndarray:
+    return np.load(os.path.join(indices_dir, filename))
+
+
+def to_device(batch: Dict[str, torch.Tensor], device: torch.device) -> Dict[str, torch.Tensor]:
+    return {k: v.to(device, non_blocking=True) for k, v in batch.items()}
+
+
+def get_rng_state() -> Dict[str, Any]:
+    state: Dict[str, Any] = {
+        "python_random_state": random.getstate(),
+        "numpy_random_state": np.random.get_state(),
+        "torch_rng_state": torch.random.get_rng_state(),
+    }
+    if torch.cuda.is_available():
+        state["cuda_rng_state_all"] = torch.cuda.get_rng_state_all()
+    else:
+        state["cuda_rng_state_all"] = None
+    return state
+
+
+def set_rng_state(state: Dict[str, Any]) -> None:
+    if state.get("python_random_state") is not None:
+        random.setstate(state["python_random_state"])
+    if state.get("numpy_random_state") is not None:
+        np.random.set_state(state["numpy_random_state"])
+    if state.get("torch_rng_state") is not None:
+        torch.random.set_rng_state(state["torch_rng_state"])
+    if torch.cuda.is_available() and state.get("cuda_rng_state_all") is not None:
+        torch.cuda.set_rng_state_all(state["cuda_rng_state_all"])
+
+
+def grad_global_norm(module: torch.nn.Module) -> float:
+    total = 0.0
+    found = False
+    for param in module.parameters():
+        if param.grad is None:
+            continue
+        g = param.grad.detach()
+        total += float(torch.sum(g.float() * g.float()).item())
+        found = True
+    if not found:
+        return 0.0
+    return total ** 0.5
+
+
+def save_checkpoint(
+    path: str,
+    enc_ctx: torch.nn.Module,
+    enc_tgt: torch.nn.Module,
+    predictor: torch.nn.Module,
+    optimizer: torch.optim.Optimizer,
+    scaler: Optional[torch.cuda.amp.GradScaler],
+    empty_region_emb: Optional[torch.Tensor],
+    step: int,
+    epoch: int,
+    it: int,
+    cfg: Dict[str, Any],
+) -> None:
+    ckpt = {
+        "step": int(step),
+        "epoch": int(epoch),
+        "it": int(it),
+        "cfg": cfg,
+        "enc_ctx": unwrap_ddp(enc_ctx).state_dict(),
+        "enc_tgt": unwrap_ddp(enc_tgt).state_dict(),
+        "predictor": unwrap_ddp(predictor).state_dict(),
+        "optimizer": optimizer.state_dict(),
+        "scaler": scaler.state_dict() if scaler is not None else None,
+        "rng_state": get_rng_state(),
+        "empty_region_emb": empty_region_emb.detach().to("cpu") if empty_region_emb is not None else None,
+    }
+    torch.save(ckpt, path)
+
+
+def save_inference_checkpoint(
+    path: str,
+    enc_ctx: torch.nn.Module,
+    enc_tgt: torch.nn.Module,
+    predictor: torch.nn.Module,
+    empty_region_emb: Optional[torch.Tensor],
+    step: int,
+    epoch: int,
+    cfg: Dict[str, Any],
+) -> None:
+    ckpt = {
+        "step": int(step),
+        "epoch": int(epoch),
+        "cfg": cfg,
+        "enc_ctx_tunable": export_encoder_tunable_state(unwrap_ddp(enc_ctx)),
+        "enc_tgt_tunable": export_encoder_tunable_state(unwrap_ddp(enc_tgt)),
+        "predictor": unwrap_ddp(predictor).state_dict(),
+        "empty_region_emb": empty_region_emb.detach().to("cpu") if empty_region_emb is not None else None,
+    }
+    torch.save(ckpt, path)
+
+
+def retrieval_top1_acc(pred: torch.Tensor, target: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    pred = F.normalize(pred.float(), dim=-1, eps=eps)
+    target = F.normalize(target.float(), dim=-1, eps=eps)
+    sim = pred @ target.t()
+    pred_idx = sim.argmax(dim=1)
+    gt_idx = torch.arange(sim.size(0), device=sim.device)
+    return (pred_idx == gt_idx).float().mean()
+
+
+def emb_std_mean(x: torch.Tensor) -> torch.Tensor:
+    return x.float().std(dim=0, unbiased=False).mean()
+
+
+def masked_full_mean_pool(hidden: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+    mask = attention_mask.to(dtype=hidden.dtype).unsqueeze(-1)
+    summed = (hidden * mask).sum(dim=1)
+    denom = mask.sum(dim=1).clamp_min(1.0)
+    return summed / denom
+
+
+def weighted_mean_pool(hidden: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
+    w = weights.to(dtype=hidden.dtype).unsqueeze(-1)
+    summed = (hidden * w).sum(dim=1)
+    denom = w.sum(dim=1).clamp_min(1e-8)
+    return summed / denom
+
+
+def build_change_plus_shared_weights(
+    attention_mask: torch.Tensor,
+    regions,
+    side: str,
+    shared_weight: float,
+) -> torch.Tensor:
+    seq_len = attention_mask.size(1)
+    weights = attention_mask.to(dtype=torch.float32) * float(shared_weight)
+    for i, region in enumerate(regions):
+        if side == "buggy":
+            start, end = region.buggy_start, region.buggy_end
+        elif side == "fixed":
+            start, end = region.fixed_start, region.fixed_end
+        else:
+            raise ValueError(f"Unknown side='{side}'")
+        change_mask = span_mask(seq_len, start, end, device=attention_mask.device).to(dtype=torch.float32)
+        weights[i] = torch.maximum(weights[i], change_mask)
+    return weights
+
+
+def get_supervision_pair(
+    cfg: Dict[str, Any],
+    tok_buggy: Dict[str, torch.Tensor],
+    tok_fixed: Dict[str, torch.Tensor],
+    z_pred: torch.Tensor,
+    z_tgt: torch.Tensor,
+    empty_region_emb: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    supervision_target = str(cfg.get("loss", {}).get("supervision_target", "change_region")).lower()
+    if supervision_target == "change_region":
+        regions = find_change_regions_in_batch(
+            tok_buggy["input_ids"],
+            tok_fixed["input_ids"],
+            tok_buggy["attention_mask"],
+            tok_fixed["attention_mask"],
+            ignore_token_ids=None,
+        )
+        return pool_change_regions(
+            z_pred,
+            z_tgt,
+            regions,
+            pred_empty_embedding=empty_region_emb,
+            tgt_empty_embedding=empty_region_emb,
+        )
+    if supervision_target == "change_plus_shared":
+        shared_weight = float(cfg.get("loss", {}).get("shared_weight", 0.1))
+        regions = find_change_regions_in_batch(
+            tok_buggy["input_ids"],
+            tok_fixed["input_ids"],
+            tok_buggy["attention_mask"],
+            tok_fixed["attention_mask"],
+            ignore_token_ids=None,
+        )
+        pred_weights = build_change_plus_shared_weights(
+            tok_buggy["attention_mask"],
+            regions,
+            side="buggy",
+            shared_weight=shared_weight,
+        )
+        tgt_weights = build_change_plus_shared_weights(
+            tok_fixed["attention_mask"],
+            regions,
+            side="fixed",
+            shared_weight=shared_weight,
+        )
+        pred_mix = weighted_mean_pool(z_pred, pred_weights)
+        tgt_mix = weighted_mean_pool(z_tgt, tgt_weights)
+        return pred_mix, tgt_mix
+    if supervision_target == "full_sequence":
+        pred_full = masked_full_mean_pool(z_pred, tok_buggy["attention_mask"])
+        tgt_full = masked_full_mean_pool(z_tgt, tok_fixed["attention_mask"])
+        return pred_full, tgt_full
+    raise ValueError(f"Unknown loss.supervision_target='{supervision_target}'")
+
+
+def wandb_init_if_needed(cfg: Dict[str, Any], out_dir: str) -> None:
+    wcfg = cfg.get("wandb", {})
+    if not bool(wcfg.get("enabled", False)):
+        return
+    if wandb is None:
+        raise RuntimeError("wandb is enabled but not installed.")
+    if not is_main():
+        return
+
+    wandb.init(
+        entity=wcfg.get("entity") or None,
+        project=wcfg.get("project") or None,
+        group=wcfg.get("group") or None,
+        name=wcfg.get("run_name") or None,
+        id=wcfg.get("id") or None,
+        resume=wcfg.get("resume", "auto"),
+        config=cfg,
+        dir=out_dir,
+    )
+
+
+def wandb_log_if_needed(cfg: Dict[str, Any], metrics: Dict[str, Any], step: int) -> None:
+    if not bool(cfg.get("wandb", {}).get("enabled", False)):
+        return
+    if wandb is None or not is_main():
+        return
+    wandb.log(metrics, step=step)
+
+
+def wandb_finish_if_needed(cfg: Dict[str, Any]) -> None:
+    if not bool(cfg.get("wandb", {}).get("enabled", False)):
+        return
+    if wandb is None or not is_main():
+        return
+    wandb.finish()
+
+
+def build_dataloaders(cfg: Dict[str, Any], tokenizer, use_ddp: bool):
+    assert cfg["data"]["source"] == "hf", "This train script expects data.source=hf."
+    hf_cfg = cfg["data"]["hf"]
+    idx_cfg = cfg["data"]["indices"]
+
+    dataset_id = hf_cfg["dataset_id"]
+    split_name = hf_cfg.get("split", "train")
+
+    global_target_dir = idx_cfg["global_target_dir"]
+    split_dir = idx_cfg["split_dir"]
+    global_target_idx = load_indices(global_target_dir, idx_cfg["global_target"])
+    train_idx = load_indices(split_dir, idx_cfg["train"])
+    val_idx = load_indices(split_dir, idx_cfg["val"])
+
+    ds_full = load_dataset(dataset_id, split=split_name)
+    ds_subset = ds_full.select(global_target_idx.tolist())
+    ds_train = ds_subset.select(train_idx.tolist())
+    ds_val = ds_subset.select(val_idx.tolist())
+
+    buggy_key = hf_cfg["fields"]["buggy"]
+    fixed_key = hf_cfg["fields"]["fixed"]
+    max_len = int(cfg["encoder"]["max_len"])
+
+    def collate_fn(batch):
+        buggy = [str(x.get(buggy_key, "") or "") for x in batch]
+        fixed = [str(x.get(fixed_key, "") or "") for x in batch]
+        tok_buggy = tokenizer(
+            buggy,
+            padding=True,
+            truncation=True,
+            max_length=max_len,
+            return_tensors="pt",
+        )
+        tok_fixed = tokenizer(
+            fixed,
+            padding=True,
+            truncation=True,
+            max_length=max_len,
+            return_tensors="pt",
+        )
+        return tok_buggy, tok_fixed
+
+    train_sampler = DistributedSampler(ds_train, shuffle=True) if use_ddp else None
+    val_sampler = DistributedSampler(ds_val, shuffle=False) if use_ddp else None
+
+    batch_size = int(cfg["train"]["batch_size"])
+    num_workers = int(cfg["data"].get("num_workers", 4))
+
+    dl_train = DataLoader(
+        ds_train,
+        batch_size=batch_size,
+        shuffle=(train_sampler is None),
+        sampler=train_sampler,
+        num_workers=num_workers,
+        pin_memory=True,
+        collate_fn=collate_fn,
+        drop_last=True,
+    )
+    dl_val = DataLoader(
+        ds_val,
+        batch_size=batch_size,
+        shuffle=False,
+        sampler=val_sampler,
+        num_workers=num_workers,
+        pin_memory=True,
+        collate_fn=collate_fn,
+        drop_last=False,
+    )
+    return dl_train, dl_val, train_sampler, val_sampler
+
+
+def run_validation(
+    cfg: Dict[str, Any],
+    enc_ctx: torch.nn.Module,
+    enc_tgt: torch.nn.Module,
+    predictor: torch.nn.Module,
+    loss_fn: torch.nn.Module,
+    dl_val: DataLoader,
+    val_sampler: Optional[DistributedSampler],
+    device: torch.device,
+    epoch: int,
+    global_step: int,
+    metrics_logger: Optional[JSONLLogger],
+    empty_region_emb: Optional[torch.Tensor],
+) -> Dict[str, float]:
+    enc_ctx.eval()
+    predictor.eval()
+    enc_tgt.eval()
+    if ddp_enabled() and val_sampler is not None:
+        val_sampler.set_epoch(epoch)
+
+    meter_loss = AverageMeter()
+    meter_align = AverageMeter()
+    meter_var = AverageMeter()
+    meter_cov = AverageMeter()
+    meter_top1 = AverageMeter()
+    meter_std_pred = AverageMeter()
+    meter_std_tgt = AverageMeter()
+
+    with torch.no_grad():
+        for tok_buggy, tok_fixed in dl_val:
+            tok_buggy = to_device(tok_buggy, device)
+            tok_fixed = to_device(tok_fixed, device)
+
+            z_ctx = enc_ctx(tok_buggy["input_ids"], tok_buggy["attention_mask"])
+            z_tgt = enc_tgt(tok_fixed["input_ids"], tok_fixed["attention_mask"])
+            z_pred = predictor(z_ctx, attention_mask=tok_buggy["attention_mask"])
+
+            pred_region, tgt_region = get_supervision_pair(
+                cfg,
+                tok_buggy,
+                tok_fixed,
+                z_pred,
+                z_tgt,
+                empty_region_emb=empty_region_emb,
+            )
+            out = loss_fn(pred_region, tgt_region)
+
+            bsz = pred_region.size(0)
+            meter_loss.update(out["loss"].item(), bsz)
+            meter_align.update(out["align"].item(), bsz)
+            meter_var.update(out["var"].item(), bsz)
+            meter_cov.update(out["cov"].item(), bsz)
+            meter_top1.update(retrieval_top1_acc(pred_region, tgt_region).item(), bsz)
+            meter_std_pred.update(emb_std_mean(pred_region).item(), bsz)
+            meter_std_tgt.update(emb_std_mean(tgt_region).item(), bsz)
+
+    t = torch.tensor(
+        [
+            meter_loss.sum, meter_loss.count,
+            meter_align.sum, meter_align.count,
+            meter_var.sum, meter_var.count,
+            meter_cov.sum, meter_cov.count,
+            meter_top1.sum, meter_top1.count,
+            meter_std_pred.sum, meter_std_pred.count,
+            meter_std_tgt.sum, meter_std_tgt.count,
+        ],
+        dtype=torch.float64,
+        device=device,
+    )
+    ddp_all_reduce_sum(t)
+    values = t.tolist()
+
+    def avg(s: float, c: float) -> float:
+        return s / max(1.0, c)
+
+    metrics = {
+        "val_loss": avg(values[0], values[1]),
+        "val_align": avg(values[2], values[3]),
+        "val_var": avg(values[4], values[5]),
+        "val_cov": avg(values[6], values[7]),
+        "val_top1": avg(values[8], values[9]),
+        "val_std_pred": avg(values[10], values[11]),
+        "val_std_tgt": avg(values[12], values[13]),
+    }
+
+    if is_main():
+        print(
+            f"[ep {epoch} step {global_step}] VAL "
+            f"loss={metrics['val_loss']:.4f} align={metrics['val_align']:.4f} "
+            f"var={metrics['val_var']:.4f} cov={metrics['val_cov']:.4f} "
+            f"top1={metrics['val_top1']:.3f}"
+        )
+        if metrics_logger is not None:
+            metrics_logger.log({"split": "val", "step": global_step, "epoch": epoch, **metrics, "time": time.time()})
+        wandb_log_if_needed(
+            cfg,
+            {
+                "val/loss": metrics["val_loss"],
+                "val/align": metrics["val_align"],
+                "val/var": metrics["val_var"],
+                "val/cov": metrics["val_cov"],
+                "val/top1": metrics["val_top1"],
+                "val/std_pred": metrics["val_std_pred"],
+                "val/std_tgt": metrics["val_std_tgt"],
+                "epoch": epoch,
+            },
+            step=global_step,
+        )
+    return metrics
+
+
+def train(cfg: Dict[str, Any]) -> None:
+    use_ddp = bool(cfg.get("ddp", {}).get("enabled", False)) and ddp_enabled()
+    if use_ddp:
+        ddp_setup(cfg.get("ddp", {}).get("backend", "nccl"))
+
+    device = torch.device("cuda", ddp_local_rank()) if torch.cuda.is_available() else torch.device("cpu")
+    seed_everything(int(cfg.get("seed", 42)) + rank())
+
+    run_name = cfg.get("run", {}).get("run_name", "run")
+    save_root = cfg.get("run", {}).get("save_dir", "./checkpoints")
+    job_id = os.environ.get("SLURM_JOB_ID", "")
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    out_dir = os.path.join(save_root, f"{run_name}_{ts}" + (f"_job{job_id}" if job_id else ""))
+    ckpt_dir = os.path.join(out_dir, "checkpoints")
+
+    metrics_logger = None
+    if is_main():
+        os.makedirs(ckpt_dir, exist_ok=True)
+        save_resolved_config(cfg, out_dir)
+        metrics_logger = JSONLLogger(os.path.join(out_dir, "metrics.jsonl"))
+
+    wandb_init_if_needed(cfg, out_dir)
+
+    tokenizer = AutoTokenizer.from_pretrained(cfg["encoder"]["name"], use_fast=True)
+    dl_train, dl_val, train_sampler, val_sampler = build_dataloaders(cfg, tokenizer, use_ddp)
+
+    enc_ctx, hidden_dim = build_encoder(cfg, device=device)
+    enc_tgt, _ = build_encoder(cfg, device=device)
+    enc_tgt.load_state_dict(unwrap_ddp(enc_ctx).state_dict(), strict=True)
+    for p in enc_tgt.parameters():
+        p.requires_grad = False
+    enc_tgt.eval()
+
+    predictor = build_predictor(cfg, hidden_dim=hidden_dim, device=device)
+    empty_region_emb = torch.nn.Parameter(torch.zeros(hidden_dim, device=device))
+
+    enc_ctx_trainable = sum(p.numel() for p in enc_ctx.parameters() if p.requires_grad)
+    predictor_trainable = sum(p.numel() for p in predictor.parameters() if p.requires_grad)
+    if is_main():
+        print(
+            f"[Params] encoder.train_mode={cfg['encoder'].get('train_mode', 'frozen')} "
+            f"enc_ctx_trainable={enc_ctx_trainable} predictor_trainable={predictor_trainable}"
+        )
+    if enc_ctx_trainable == 0:
+        raise RuntimeError(
+            "Context encoder has no trainable parameters. "
+            "This usually means encoder.train_mode stayed 'frozen' or LoRA overrides were not applied."
+        )
+    if predictor_trainable == 0:
+        raise RuntimeError("Predictor has no trainable parameters.")
+
+    if use_ddp:
+        find_unused = bool(cfg.get("ddp", {}).get("find_unused_parameters", False))
+        enc_ctx = DDP(enc_ctx, device_ids=[ddp_local_rank()], find_unused_parameters=find_unused)
+        predictor = DDP(predictor, device_ids=[ddp_local_rank()], find_unused_parameters=find_unused)
+
+    loss_fn = build_loss(cfg).to(device)
+
+    lr_encoder = float(cfg["train"].get("lr_encoder", cfg["train"].get("lr", 2e-5)))
+    lr_predictor = float(cfg["train"].get("lr_predictor", cfg["train"].get("lr", 1e-4)))
+    wd = float(cfg["train"].get("weight_decay", 0.01))
+    betas = tuple(cfg.get("optim", {}).get("betas", [0.9, 0.999]))
+    eps = float(cfg.get("optim", {}).get("eps", 1e-8))
+
+    optimizer = torch.optim.AdamW(
+        [
+            {"params": [p for p in unwrap_ddp(enc_ctx).parameters() if p.requires_grad], "lr": lr_encoder},
+            {"params": [p for p in unwrap_ddp(predictor).parameters() if p.requires_grad], "lr": lr_predictor},
+            {"params": [empty_region_emb], "lr": lr_predictor},
+        ],
+        weight_decay=wd,
+        betas=betas,
+        eps=eps,
+    )
+
+    use_fp16 = bool(cfg["train"].get("fp16", True)) and device.type == "cuda"
+    scaler = torch.cuda.amp.GradScaler(enabled=use_fp16)
+
+    global_step = 0
+    resume_epoch = 0
+    resume_it = 0
+    best_val = float("inf")
+
+    resume_path = str(cfg["train"].get("resume_from", "") or "")
+    if resume_path:
+        if is_main():
+            print(f"[Resume] Loading checkpoint: {resume_path}")
+        ckpt = torch.load(resume_path, map_location="cpu", weights_only=False)
+        if "enc_ctx" in ckpt:
+            unwrap_ddp(enc_ctx).load_state_dict(ckpt["enc_ctx"], strict=True)
+        elif "enc_ctx_tunable" in ckpt:
+            load_encoder_tunable_state(unwrap_ddp(enc_ctx), ckpt["enc_ctx_tunable"], strict=False)
+
+        if "enc_tgt" in ckpt:
+            enc_tgt.load_state_dict(ckpt["enc_tgt"], strict=True)
+        elif "enc_tgt_tunable" in ckpt:
+            load_encoder_tunable_state(unwrap_ddp(enc_tgt), ckpt["enc_tgt_tunable"], strict=False)
+
+        unwrap_ddp(predictor).load_state_dict(ckpt["predictor"], strict=True)
+        if ckpt.get("optimizer") is not None:
+            optimizer.load_state_dict(ckpt["optimizer"])
+        if ckpt.get("scaler") is not None:
+            scaler.load_state_dict(ckpt["scaler"])
+        if ckpt.get("empty_region_emb") is not None:
+            empty_region_emb.data.copy_(ckpt["empty_region_emb"].to(device=device, dtype=empty_region_emb.dtype))
+        global_step = int(ckpt.get("step", 0))
+        resume_epoch = int(ckpt.get("epoch", 0))
+        resume_it = int(ckpt.get("it", 0))
+        best_val = float(ckpt.get("best_val_loss", best_val))
+        if bool(cfg["train"].get("resume_restore_rng", False)) and ckpt.get("rng_state") is not None:
+            set_rng_state(ckpt["rng_state"])
+
+    epochs = int(cfg["train"]["epochs"])
+    grad_accum = int(cfg["train"].get("grad_accum", 1))
+    log_every = int(cfg["train"].get("log_every", 50))
+    eval_every_steps = int(cfg["train"].get("eval_every_steps", 0))
+    save_every_steps = int(cfg["train"].get("save_every_steps", 0))
+    save_every_epoch = bool(cfg["train"].get("save_every_epoch", False))
+    tau = float(cfg.get("ema", {}).get("tau", 0.996))
+    best_path = os.path.join(ckpt_dir, "ckpt_best.pt")
+    last_path = os.path.join(ckpt_dir, "ckpt_last.pt")
+
+    steps_per_epoch = max(1, len(dl_train) // max(1, grad_accum))
+    start_epoch = global_step // steps_per_epoch
+    start_step_in_epoch = global_step % steps_per_epoch
+
+    if is_main():
+        print(f"[Info] Output dir: {out_dir}")
+        print(f"[Info] steps_per_epoch={steps_per_epoch}, start_epoch={start_epoch}, start_step_in_epoch={start_step_in_epoch}")
+
+    for epoch in range(start_epoch, epochs):
+        if use_ddp and train_sampler is not None:
+            train_sampler.set_epoch(epoch)
+
+        enc_ctx.train()
+        predictor.train()
+        optimizer.zero_grad(set_to_none=True)
+
+        skip_batches = start_step_in_epoch * grad_accum if epoch == start_epoch else 0
+
+        meter_loss = AverageMeter()
+        meter_align = AverageMeter()
+        meter_var = AverageMeter()
+        meter_cov = AverageMeter()
+        meter_top1 = AverageMeter()
+
+        iterator = tqdm(dl_train, desc=f"Epoch {epoch}", dynamic_ncols=True) if is_main() else dl_train
+        for it, (tok_buggy, tok_fixed) in enumerate(iterator):
+            if skip_batches > 0 and it < skip_batches:
+                continue
+
+            tok_buggy = to_device(tok_buggy, device)
+            tok_fixed = to_device(tok_fixed, device)
+
+            with torch.cuda.amp.autocast(enabled=use_fp16):
+                z_ctx = enc_ctx(tok_buggy["input_ids"], tok_buggy["attention_mask"])
+                with torch.no_grad():
+                    z_tgt = enc_tgt(tok_fixed["input_ids"], tok_fixed["attention_mask"])
+                z_pred = predictor(z_ctx, attention_mask=tok_buggy["attention_mask"])
+
+                pred_region, tgt_region = get_supervision_pair(
+                    cfg,
+                    tok_buggy,
+                    tok_fixed,
+                    z_pred,
+                    z_tgt,
+                    empty_region_emb=empty_region_emb,
+                )
+                out = loss_fn(pred_region, tgt_region)
+                loss = out["loss"] / max(1, grad_accum)
+
+            scaler.scale(loss).backward()
+
+            bsz = pred_region.size(0)
+            meter_loss.update(out["loss"].item(), bsz)
+            meter_align.update(out["align"].item(), bsz)
+            meter_var.update(out["var"].item(), bsz)
+            meter_cov.update(out["cov"].item(), bsz)
+            meter_top1.update(retrieval_top1_acc(pred_region, tgt_region).item(), bsz)
+
+            if (it + 1) % grad_accum == 0:
+                scaler.unscale_(optimizer)
+                enc_ctx_grad_norm = grad_global_norm(unwrap_ddp(enc_ctx))
+                predictor_grad_norm = grad_global_norm(unwrap_ddp(predictor))
+                grad_norm_ratio = predictor_grad_norm / max(enc_ctx_grad_norm, 1e-12)
+                scaler.step(optimizer)
+                scaler.update()
+                optimizer.zero_grad(set_to_none=True)
+                ema_update(enc_tgt, enc_ctx, tau=tau)
+                global_step += 1
+
+                if is_main() and (global_step % log_every == 0):
+                    train_metrics = {
+                        "train/loss": meter_loss.avg,
+                        "train/align": meter_align.avg,
+                        "train/var": meter_var.avg,
+                        "train/cov": meter_cov.avg,
+                        "train/top1": meter_top1.avg,
+                        "train/enc_ctx_grad_norm": enc_ctx_grad_norm,
+                        "train/predictor_grad_norm": predictor_grad_norm,
+                        "train/predictor_to_encoder_grad_ratio": grad_norm_ratio,
+                        "epoch": epoch,
+                    }
+                    print(
+                        f"[ep {epoch} step {global_step}] TRAIN "
+                        f"loss={meter_loss.avg:.4f} align={meter_align.avg:.4f} "
+                        f"var={meter_var.avg:.4f} cov={meter_cov.avg:.4f} "
+                        f"top1={meter_top1.avg:.3f} "
+                        f"enc_gn={enc_ctx_grad_norm:.4f} pred_gn={predictor_grad_norm:.4f} "
+                        f"pred/enc={grad_norm_ratio:.3f}"
+                    )
+                    wandb_log_if_needed(cfg, train_metrics, step=global_step)
+                    if metrics_logger is not None:
+                        metrics_logger.log(
+                            {
+                                "split": "train",
+                                "step": global_step,
+                                "epoch": epoch,
+                                "loss": meter_loss.avg,
+                                "align": meter_align.avg,
+                                "var": meter_var.avg,
+                                "cov": meter_cov.avg,
+                                "top1": meter_top1.avg,
+                                "enc_ctx_grad_norm": enc_ctx_grad_norm,
+                                "predictor_grad_norm": predictor_grad_norm,
+                                "predictor_to_encoder_grad_ratio": grad_norm_ratio,
+                                "time": time.time(),
+                            }
+                        )
+
+                if save_every_steps > 0 and (global_step % save_every_steps == 0) and is_main():
+                    step_path = os.path.join(ckpt_dir, f"ckpt_step{global_step}.pt")
+                    save_checkpoint(step_path, enc_ctx, enc_tgt, predictor, optimizer, scaler, empty_region_emb, global_step, epoch, it, cfg)
+
+                if eval_every_steps > 0 and (global_step % eval_every_steps == 0):
+                    val_metrics = run_validation(
+                        cfg,
+                        enc_ctx,
+                        enc_tgt,
+                        predictor,
+                        loss_fn,
+                        dl_val,
+                        val_sampler,
+                        device,
+                        epoch,
+                        global_step,
+                        metrics_logger,
+                        empty_region_emb,
+                    )
+                    if is_main() and val_metrics["val_loss"] < best_val:
+                        best_val = val_metrics["val_loss"]
+                        save_inference_checkpoint(best_path, enc_ctx, enc_tgt, predictor, empty_region_emb, global_step, epoch, cfg)
+                        ckpt = torch.load(best_path, map_location="cpu", weights_only=False)
+                        ckpt["best_val_loss"] = best_val
+                        torch.save(ckpt, best_path)
+                        print(f"[Best] Saved best checkpoint to {best_path}")
+                    enc_ctx.train()
+                    predictor.train()
+
+        val_metrics = run_validation(
+            cfg,
+            enc_ctx,
+            enc_tgt,
+            predictor,
+            loss_fn,
+            dl_val,
+            val_sampler,
+            device,
+            epoch,
+            global_step,
+            metrics_logger,
+            empty_region_emb,
+        )
+        if is_main() and val_metrics["val_loss"] < best_val:
+            best_val = val_metrics["val_loss"]
+            save_inference_checkpoint(best_path, enc_ctx, enc_tgt, predictor, empty_region_emb, global_step, epoch, cfg)
+            ckpt = torch.load(best_path, map_location="cpu", weights_only=False)
+            ckpt["best_val_loss"] = best_val
+            torch.save(ckpt, best_path)
+            print(f"[Best] Saved best checkpoint to {best_path}")
+
+        if is_main() and save_every_epoch:
+            epoch_path = os.path.join(ckpt_dir, f"ckpt_epoch{epoch + 1}.pt")
+            save_checkpoint(epoch_path, enc_ctx, enc_tgt, predictor, optimizer, scaler, empty_region_emb, global_step, epoch, len(dl_train), cfg)
+            ckpt = torch.load(epoch_path, map_location="cpu", weights_only=False)
+            ckpt["best_val_loss"] = best_val
+            torch.save(ckpt, epoch_path)
+
+    if is_main():
+        save_checkpoint(last_path, enc_ctx, enc_tgt, predictor, optimizer, scaler, empty_region_emb, global_step, epochs - 1, len(dl_train), cfg)
+        ckpt = torch.load(last_path, map_location="cpu", weights_only=False)
+        ckpt["best_val_loss"] = best_val
+        torch.save(ckpt, last_path)
+
+    wandb_finish_if_needed(cfg)
+    if use_ddp:
+        ddp_cleanup()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, required=True)
+    parser.add_argument("--set", nargs="*", action="append", default=[])
+    args = parser.parse_args()
+
+    cfg = resolve_config(args.config, flatten_overrides(args.set))
+    train(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/JEPA_region/src/utils.py
+++ b/JEPA_region/src/utils.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import json
+import os
+import random
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import yaml
+
+
+def load_yaml(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def deep_update(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_update(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def _cast_value(value: str) -> Any:
+    text = value.strip()
+    if text.lower() in {"true", "false"}:
+        return text.lower() == "true"
+    if text.lower() in {"none", "null"}:
+        return None
+    if text.startswith("[") and text.endswith("]"):
+        inner = text[1:-1].strip()
+        if not inner:
+            return []
+        return [_cast_value(x.strip()) for x in inner.split(",")]
+    try:
+        if "." in text or "e" in text.lower():
+            return float(text)
+        return int(text)
+    except ValueError:
+        return text
+
+
+def set_by_dotted_key(cfg: Dict[str, Any], dotted: str, value: Any) -> None:
+    keys = dotted.split(".")
+    cur = cfg
+    for key in keys[:-1]:
+        if key not in cur or not isinstance(cur[key], dict):
+            cur[key] = {}
+        cur = cur[key]
+    cur[keys[-1]] = value
+
+
+def apply_overrides(cfg: Dict[str, Any], overrides: List[str]) -> Dict[str, Any]:
+    for item in overrides:
+        if "=" not in item:
+            raise ValueError(f"Bad override '{item}', expected key=value")
+        key, value = item.split("=", 1)
+        set_by_dotted_key(cfg, key.strip(), _cast_value(value.strip()))
+    return cfg
+
+
+def save_json(obj: Any, path: str) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(obj, f, ensure_ascii=False, indent=2)
+
+
+def save_resolved_config(cfg: Dict[str, Any], out_dir: str, filename: str = "resolved_config.json") -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    save_json(cfg, os.path.join(out_dir, filename))
+
+
+def seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def is_ddp_env() -> bool:
+    return "RANK" in os.environ and "WORLD_SIZE" in os.environ
+
+
+def ddp_enabled() -> bool:
+    return is_ddp_env()
+
+
+def rank() -> int:
+    return int(os.environ.get("RANK", "0"))
+
+
+def ddp_rank() -> int:
+    return rank()
+
+
+def local_rank() -> int:
+    return int(os.environ.get("LOCAL_RANK", "0"))
+
+
+def ddp_local_rank() -> int:
+    return local_rank()
+
+
+def world_size() -> int:
+    return int(os.environ.get("WORLD_SIZE", "1"))
+
+
+def ddp_world() -> int:
+    return world_size()
+
+
+def is_main() -> bool:
+    return rank() == 0
+
+
+def ddp_setup(backend: str = "nccl") -> None:
+    if not ddp_enabled():
+        return
+    if not dist.is_initialized():
+        dist.init_process_group(backend=backend)
+    if torch.cuda.is_available():
+        torch.cuda.set_device(local_rank())
+
+
+def ddp_cleanup() -> None:
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def ddp_barrier() -> None:
+    if dist.is_initialized():
+        dist.barrier()
+
+
+def ddp_all_reduce_sum(tensor: torch.Tensor) -> torch.Tensor:
+    if dist.is_initialized():
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
+    return tensor
+
+
+def unwrap_ddp(module: nn.Module) -> nn.Module:
+    return module.module if hasattr(module, "module") else module
+
+
+@torch.no_grad()
+def ema_update(teacher: nn.Module, student: nn.Module, tau: float) -> None:
+    teacher = unwrap_ddp(teacher)
+    student = unwrap_ddp(student)
+    for teacher_param, student_param in zip(teacher.parameters(), student.parameters()):
+        teacher_param.data.mul_(tau).add_(student_param.data, alpha=1.0 - tau)
+
+
+class AverageMeter:
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self.sum = 0.0
+        self.count = 0
+
+    def update(self, value: float, n: int = 1) -> None:
+        self.sum += float(value) * int(n)
+        self.count += int(n)
+
+    @property
+    def avg(self) -> float:
+        return self.sum / max(1, self.count)
+
+
+class JSONLLogger:
+    def __init__(self, path: str):
+        self.path = path
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+
+    def log(self, record: Dict[str, Any]) -> None:
+        with open(self.path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def valid_token_ids(
+    input_ids: Sequence[int],
+    attention_mask: Optional[Sequence[int]] = None,
+    ignore_token_ids: Optional[set[int]] = None,
+) -> List[int]:
+    ignore_token_ids = ignore_token_ids or set()
+    output: List[int] = []
+    for idx, token_id in enumerate(input_ids):
+        if attention_mask is not None and int(attention_mask[idx]) == 0:
+            break
+        if int(token_id) in ignore_token_ids:
+            continue
+        output.append(int(token_id))
+    return output
+
+
+@dataclass
+class ChangeRegion:
+    left_len: int
+    buggy_start: int
+    buggy_end: int
+    fixed_start: int
+    fixed_end: int
+    right_len: int
+
+    @property
+    def buggy_len(self) -> int:
+        return self.buggy_end - self.buggy_start
+
+    @property
+    def fixed_len(self) -> int:
+        return self.fixed_end - self.fixed_start
+
+
+def find_change_region(
+    buggy_token_ids: Sequence[int],
+    fixed_token_ids: Sequence[int],
+) -> ChangeRegion:
+    buggy = list(buggy_token_ids)
+    fixed = list(fixed_token_ids)
+
+    left = 0
+    min_len = min(len(buggy), len(fixed))
+    while left < min_len and buggy[left] == fixed[left]:
+        left += 1
+
+    buggy_right = len(buggy)
+    fixed_right = len(fixed)
+    while buggy_right > left and fixed_right > left and buggy[buggy_right - 1] == fixed[fixed_right - 1]:
+        buggy_right -= 1
+        fixed_right -= 1
+
+    right_len = len(buggy) - buggy_right
+    return ChangeRegion(
+        left_len=left,
+        buggy_start=left,
+        buggy_end=buggy_right,
+        fixed_start=left,
+        fixed_end=fixed_right,
+        right_len=right_len,
+    )
+
+
+def find_change_region_from_inputs(
+    buggy_input_ids: Sequence[int],
+    fixed_input_ids: Sequence[int],
+    buggy_attention_mask: Optional[Sequence[int]] = None,
+    fixed_attention_mask: Optional[Sequence[int]] = None,
+    ignore_token_ids: Optional[set[int]] = None,
+) -> ChangeRegion:
+    buggy = valid_token_ids(
+        buggy_input_ids,
+        attention_mask=buggy_attention_mask,
+        ignore_token_ids=ignore_token_ids,
+    )
+    fixed = valid_token_ids(
+        fixed_input_ids,
+        attention_mask=fixed_attention_mask,
+        ignore_token_ids=ignore_token_ids,
+    )
+    return find_change_region(buggy, fixed)
+
+
+def find_change_regions_in_batch(
+    buggy_input_ids: torch.Tensor,
+    fixed_input_ids: torch.Tensor,
+    buggy_attention_mask: Optional[torch.Tensor] = None,
+    fixed_attention_mask: Optional[torch.Tensor] = None,
+    ignore_token_ids: Optional[set[int]] = None,
+) -> List[ChangeRegion]:
+    regions: List[ChangeRegion] = []
+    batch_size = buggy_input_ids.size(0)
+    for i in range(batch_size):
+        region = find_change_region_from_inputs(
+            buggy_input_ids[i].tolist(),
+            fixed_input_ids[i].tolist(),
+            buggy_attention_mask[i].tolist() if buggy_attention_mask is not None else None,
+            fixed_attention_mask[i].tolist() if fixed_attention_mask is not None else None,
+            ignore_token_ids=ignore_token_ids,
+        )
+        regions.append(region)
+    return regions
+
+
+def span_mask(length: int, start: int, end: int, device: Optional[torch.device] = None) -> torch.Tensor:
+    mask = torch.zeros(length, dtype=torch.bool, device=device)
+    if end > start:
+        mask[start:end] = True
+    return mask
+
+
+def batch_span_mask(
+    seq_len: int,
+    starts: torch.Tensor,
+    ends: torch.Tensor,
+) -> torch.Tensor:
+    positions = torch.arange(seq_len, device=starts.device).unsqueeze(0)
+    return (positions >= starts.unsqueeze(1)) & (positions < ends.unsqueeze(1))
+
+
+def masked_mean_pool(hidden: torch.Tensor, mask: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    if hidden.dim() != 3:
+        raise ValueError(f"hidden must be [B, L, D], got {tuple(hidden.shape)}")
+    if mask.dim() != 2:
+        raise ValueError(f"mask must be [B, L], got {tuple(mask.shape)}")
+    weights = mask.unsqueeze(-1).to(hidden.dtype)
+    summed = (hidden * weights).sum(dim=1)
+    counts = weights.sum(dim=1).clamp(min=eps)
+    return summed / counts
+
+
+def masked_mean_pool_with_empty(
+    hidden: torch.Tensor,
+    mask: torch.Tensor,
+    empty_embedding: Optional[torch.Tensor] = None,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    pooled = masked_mean_pool(hidden, mask, eps=eps)
+    if empty_embedding is None:
+        return pooled
+
+    empty_rows = ~mask.any(dim=1)
+    if not bool(empty_rows.any()):
+        return pooled
+
+    empty_vec = empty_embedding.to(device=hidden.device, dtype=hidden.dtype).view(1, -1)
+    empty_vec = empty_vec.expand(hidden.size(0), -1)
+    empty_mask = empty_rows.to(dtype=hidden.dtype).unsqueeze(-1)
+    return pooled * (1.0 - empty_mask) + empty_vec * empty_mask
+
+
+def pool_regions_by_side(
+    hidden: torch.Tensor,
+    regions: List[ChangeRegion],
+    side: str,
+    empty_embedding: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if hidden.dim() != 3:
+        raise ValueError("hidden must be [B, L, D]")
+    if len(regions) != hidden.size(0):
+        raise ValueError("regions length must match batch size")
+
+    seq_len = hidden.size(1)
+    masks = []
+    for region in regions:
+        if side == "buggy":
+            masks.append(span_mask(seq_len, region.buggy_start, region.buggy_end, device=hidden.device))
+        elif side == "fixed":
+            masks.append(span_mask(seq_len, region.fixed_start, region.fixed_end, device=hidden.device))
+        else:
+            raise ValueError(f"Unknown side='{side}'")
+    mask = torch.stack(masks, dim=0)
+    return masked_mean_pool_with_empty(hidden, mask, empty_embedding=empty_embedding)
+
+
+def pool_change_regions(
+    pred_hidden: torch.Tensor,
+    tgt_hidden: torch.Tensor,
+    regions: List[ChangeRegion],
+    pred_empty_embedding: Optional[torch.Tensor] = None,
+    tgt_empty_embedding: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if pred_hidden.dim() != 3 or tgt_hidden.dim() != 3:
+        raise ValueError("pred_hidden and tgt_hidden must be [B, L, D]")
+    if len(regions) != pred_hidden.size(0) or len(regions) != tgt_hidden.size(0):
+        raise ValueError("regions length must match batch size")
+
+    pred_pooled = pool_regions_by_side(
+        pred_hidden,
+        regions,
+        side="buggy",
+        empty_embedding=pred_empty_embedding,
+    )
+    tgt_pooled = pool_regions_by_side(
+        tgt_hidden,
+        regions,
+        side="fixed",
+        empty_embedding=tgt_empty_embedding,
+    )
+    return pred_pooled, tgt_pooled


### PR DESCRIPTION
This PR adds JEPA_region, a region extension of the original JEPA pipeline.

The key differences are:
- prediction is performed on sequence embeddings instead of mean-pooled embeddings
- supervision is shifted from uniform global alignment to region-aware objectives
- multiple supervision modes are supported: 'change_region', 'change_plus_shared', and 'full_sequence'