### PR TITLE
add classification tasks: bug_detection and edit_type

### DIFF
--- a/JEPA_downstream/src/bug_detection/test.py
+++ b/JEPA_downstream/src/bug_detection/test.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score
+from torch.utils.data import DataLoader, Dataset
+from tqdm.auto import tqdm
+
+from common import BinaryMLP, build_binary_feature, load_method_split_embeddings, load_online_split_embeddings, save_json
+
+
+class BinaryFeatureDataset(Dataset):
+    def __init__(self, features: np.ndarray, labels: np.ndarray, meta: List[Dict[str, Any]]) -> None:
+        self.features = np.asarray(features, dtype=np.float32)
+        self.labels = np.asarray(labels, dtype=np.float32)
+        self.meta = meta
+
+    def __len__(self) -> int:
+        return len(self.features)
+
+    def __getitem__(self, idx: int):
+        return torch.from_numpy(self.features[idx]).float(), torch.tensor(self.labels[idx], dtype=torch.float32), self.meta[idx]
+
+
+def make_dataloader(dataset: Dataset, batch_size: int, shuffle: bool, num_workers: int) -> DataLoader:
+    kwargs: Dict[str, Any] = {
+        "dataset": dataset,
+        "batch_size": batch_size,
+        "shuffle": shuffle,
+        "num_workers": num_workers,
+        "pin_memory": torch.cuda.is_available(),
+    }
+    if num_workers > 0:
+        kwargs["persistent_workers"] = True
+    return DataLoader(**kwargs)
+
+
+def build_binary_split(features_buggy: np.ndarray, features_fixed: np.ndarray, global_indices: np.ndarray) -> Tuple[np.ndarray, np.ndarray, List[Dict[str, Any]]]:
+    x_buggy = build_binary_feature(features_buggy, feature_mode="buggy")
+    x_fixed = build_binary_feature(features_fixed, feature_mode="buggy")
+    y_buggy = np.ones((len(x_buggy),), dtype=np.float32)
+    y_fixed = np.zeros((len(x_fixed),), dtype=np.float32)
+    x = np.concatenate([x_buggy, x_fixed], axis=0).astype(np.float32)
+    y = np.concatenate([y_buggy, y_fixed], axis=0).astype(np.float32)
+    meta: List[Dict[str, Any]] = []
+    for idx in global_indices:
+        meta.append({"global_index": int(idx), "source": "buggy"})
+    for idx in global_indices:
+        meta.append({"global_index": int(idx), "source": "fixed"})
+    return x, y, meta
+
+
+def load_split_binary_data(
+    backend: str,
+    method: str,
+    split_dir: str,
+    embedding_view: str,
+    file_kwargs: Dict[str, str],
+    online_kwargs: Dict[str, Any],
+) -> Tuple[np.ndarray, np.ndarray, List[Dict[str, Any]]]:
+    if backend == "offline_pt":
+        loaded = load_method_split_embeddings(
+            split_dir,
+            method=method,
+            embedding_view=embedding_view,
+            **file_kwargs,
+        )
+        return build_binary_split(loaded.buggy_emb, loaded.tgt_emb, loaded.global_indices)
+    if backend == "online_checkpoint":
+        loaded = load_online_split_embeddings(
+            checkpoint_path=str(online_kwargs["jepa_checkpoint"]),
+            config_path=str(online_kwargs["jepa_config"]),
+            encoder_mode=str(online_kwargs["encoder_mode"]),
+            indices_dir=str(online_kwargs["indices_dir"]),
+            indices_file=str(online_kwargs["indices_file"]),
+            global_target_dir=str(online_kwargs["global_target_dir"]),
+            global_target_file=str(online_kwargs["global_target_file"]),
+            hf_dataset_name=str(online_kwargs["hf_dataset_name"]),
+            hf_split=str(online_kwargs["hf_split"]),
+            hf_buggy_field=str(online_kwargs["hf_buggy_field"]),
+            hf_fixed_field=str(online_kwargs["hf_fixed_field"]),
+            max_len=int(online_kwargs["max_len"]),
+            batch_size=int(online_kwargs["extract_batch_size"]),
+            num_workers=int(online_kwargs["extract_num_workers"]),
+            device=online_kwargs["device"],
+        )
+        return build_binary_split(loaded.buggy_emb, loaded.tgt_emb, loaded.global_indices)
+    raise ValueError(f"Unsupported backend: {backend}")
+
+
+def compute_binary_metrics(y_true: np.ndarray, y_prob: np.ndarray, threshold: float = 0.5) -> Dict[str, float]:
+    y_pred = (y_prob >= threshold).astype(np.int32)
+    y_true = y_true.astype(np.int32)
+    return {
+        "accuracy": float(accuracy_score(y_true, y_pred)),
+        "precision": float(precision_score(y_true, y_pred, zero_division=0)),
+        "recall": float(recall_score(y_true, y_pred, zero_division=0)),
+        "f1": float(f1_score(y_true, y_pred, zero_division=0)),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Test binary buggy-vs-fixed classifier probe")
+    parser.add_argument("--checkpoint", type=str, required=True)
+    parser.add_argument("--split-dir", type=str, required=True)
+    parser.add_argument("--backend", type=str, default="", choices=["", "offline_pt", "online_checkpoint"])
+    parser.add_argument("--method", type=str, default="")
+    parser.add_argument("--embedding-view", type=str, default="", choices=["", "ctx", "tgt", "ctx_tgt"])
+    parser.add_argument("--jepa-checkpoint", type=str, default="")
+    parser.add_argument("--jepa-config", type=str, default="")
+    parser.add_argument("--encoder-mode", type=str, default="same_encoder", choices=["same_encoder", "context_target", "target_target"])
+    parser.add_argument("--indices-dir", type=str, default="")
+    parser.add_argument("--global-target-dir", type=str, default="")
+    parser.add_argument("--global-target-file", type=str, default="global_target_indices.npy")
+    parser.add_argument("--indices-file", type=str, default="test_idx.npy")
+    parser.add_argument("--hf-dataset-name", type=str, default="")
+    parser.add_argument("--hf-split", type=str, default="")
+    parser.add_argument("--hf-buggy-field", type=str, default="")
+    parser.add_argument("--hf-fixed-field", type=str, default="")
+    parser.add_argument("--max-len", type=int, default=512)
+    parser.add_argument("--extract-batch-size", type=int, default=128)
+    parser.add_argument("--extract-num-workers", type=int, default=4)
+    parser.add_argument("--global-indices-key", type=str, default="global_indices")
+    parser.add_argument("--buggy-file-name", type=str, default="")
+    parser.add_argument("--buggy-key", type=str, default="")
+    parser.add_argument("--pred-file-name", type=str, default="")
+    parser.add_argument("--pred-key", type=str, default="")
+    parser.add_argument("--tgt-file-name", type=str, default="")
+    parser.add_argument("--tgt-key", type=str, default="")
+    parser.add_argument("--buggy-ctx-file-name", type=str, default="")
+    parser.add_argument("--buggy-ctx-key", type=str, default="")
+    parser.add_argument("--fixed-ctx-file-name", type=str, default="")
+    parser.add_argument("--fixed-ctx-key", type=str, default="")
+    parser.add_argument("--buggy-tgt-file-name", type=str, default="")
+    parser.add_argument("--buggy-tgt-key", type=str, default="")
+    parser.add_argument("--fixed-tgt-file-name", type=str, default="")
+    parser.add_argument("--fixed-tgt-key", type=str, default="")
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--output-json", type=str, required=True)
+    args = parser.parse_args()
+
+    ckpt = torch.load(args.checkpoint, map_location="cpu", weights_only=False)
+    backend = args.backend or ckpt.get("backend", "offline_pt")
+    method = args.method or ckpt.get("method", "e2")
+    embedding_view = args.embedding_view or ckpt.get("embedding_view", "ctx")
+    threshold = float(ckpt.get("threshold", 0.5))
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    file_kwargs = {
+        "global_indices_key": args.global_indices_key,
+        "buggy_file_name": args.buggy_file_name,
+        "buggy_key": args.buggy_key,
+        "pred_file_name": args.pred_file_name,
+        "pred_key": args.pred_key,
+        "tgt_file_name": args.tgt_file_name,
+        "tgt_key": args.tgt_key,
+        "buggy_ctx_file_name": args.buggy_ctx_file_name,
+        "buggy_ctx_key": args.buggy_ctx_key,
+        "fixed_ctx_file_name": args.fixed_ctx_file_name,
+        "fixed_ctx_key": args.fixed_ctx_key,
+        "buggy_tgt_file_name": args.buggy_tgt_file_name,
+        "buggy_tgt_key": args.buggy_tgt_key,
+        "fixed_tgt_file_name": args.fixed_tgt_file_name,
+        "fixed_tgt_key": args.fixed_tgt_key,
+    }
+    online_kwargs = {
+        "jepa_checkpoint": args.jepa_checkpoint,
+        "jepa_config": args.jepa_config,
+        "encoder_mode": args.encoder_mode,
+        "indices_dir": args.indices_dir,
+        "indices_file": args.indices_file,
+        "global_target_dir": args.global_target_dir,
+        "global_target_file": args.global_target_file,
+        "hf_dataset_name": args.hf_dataset_name,
+        "hf_split": args.hf_split,
+        "hf_buggy_field": args.hf_buggy_field,
+        "hf_fixed_field": args.hf_fixed_field,
+        "max_len": args.max_len,
+        "extract_batch_size": args.extract_batch_size,
+        "extract_num_workers": args.extract_num_workers,
+        "device": device,
+    }
+
+    x, y, meta = load_split_binary_data(backend, method, args.split_dir, embedding_view, file_kwargs, online_kwargs)
+    ds = BinaryFeatureDataset(x, y, meta)
+    dl = make_dataloader(ds, args.batch_size, False, args.num_workers)
+    model = BinaryMLP(
+        ckpt["input_dim"],
+        hidden_dim=int(ckpt.get("hidden_dim", 512)),
+        dropout=float(ckpt.get("dropout", 0.3)),
+    )
+    model.load_state_dict(ckpt["model"])
+    model = model.to(device)
+    model.eval()
+    criterion = nn.BCEWithLogitsLoss()
+
+    running_loss = 0.0
+    total = 0
+    all_probs: List[np.ndarray] = []
+    all_targets: List[np.ndarray] = []
+    predictions: List[Dict[str, Any]] = []
+
+    with torch.no_grad():
+        for x_batch, y_batch, meta_batch in tqdm(dl, desc="[Eval]", leave=False):
+            x_batch = x_batch.to(device, non_blocking=True)
+            y_batch = y_batch.to(device, non_blocking=True)
+            logits = model(x_batch)
+            loss = criterion(logits, y_batch)
+            probs = torch.sigmoid(logits).detach().cpu().numpy()
+
+            bs = x_batch.size(0)
+            total += bs
+            running_loss += loss.item() * bs
+            all_probs.append(probs)
+            all_targets.append(y_batch.detach().cpu().numpy())
+
+            global_indices = meta_batch["global_index"]
+            sources = meta_batch["source"]
+            for global_index, source, prob in zip(global_indices, sources, probs):
+                predictions.append(
+                    {
+                        "global_index": int(global_index),
+                        "source": source,
+                        "probability_buggy": float(prob),
+                        "predicted_label": int(prob >= threshold),
+                        "target_label": 1 if source == "buggy" else 0,
+                    }
+                )
+
+    y_prob = np.concatenate(all_probs, axis=0)
+    y_true = np.concatenate(all_targets, axis=0)
+    metrics = compute_binary_metrics(y_true, y_prob, threshold=threshold)
+    metrics["loss"] = float(running_loss / max(total, 1))
+
+    output = {
+        "backend": backend,
+        "method": method,
+        "embedding_view": embedding_view,
+        "metrics": metrics,
+        "predictions": predictions,
+    }
+    save_json(output, args.output_json)
+    print(json.dumps(metrics, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/JEPA_downstream/src/bug_detection/train.py
+++ b/JEPA_downstream/src/bug_detection/train.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score
+from torch.utils.data import DataLoader, Dataset
+from tqdm.auto import tqdm
+
+from common import BinaryMLP, build_binary_feature, load_method_split_embeddings, load_online_split_embeddings, save_json, seed_everything
+
+
+try:
+    import wandb  # type: ignore
+except Exception:
+    wandb = None
+
+
+class BinaryFeatureDataset(Dataset):
+    def __init__(self, features: np.ndarray, labels: np.ndarray, meta: Optional[List[Dict[str, Any]]] = None) -> None:
+        self.features = np.asarray(features, dtype=np.float32)
+        self.labels = np.asarray(labels, dtype=np.float32)
+        self.meta = meta
+        if len(self.features) != len(self.labels):
+            raise ValueError("features and labels must have the same length")
+        if self.meta is not None and len(self.meta) != len(self.features):
+            raise ValueError("meta and features must have the same length")
+
+    def __len__(self) -> int:
+        return len(self.features)
+
+    def __getitem__(self, idx: int):
+        x = torch.from_numpy(self.features[idx]).float()
+        y = torch.tensor(self.labels[idx], dtype=torch.float32)
+        if self.meta is None:
+            return x, y
+        return x, y, self.meta[idx]
+
+
+def make_dataloader(dataset: Dataset, batch_size: int, shuffle: bool, num_workers: int) -> DataLoader:
+    kwargs: Dict[str, Any] = {
+        "dataset": dataset,
+        "batch_size": batch_size,
+        "shuffle": shuffle,
+        "num_workers": num_workers,
+        "pin_memory": torch.cuda.is_available(),
+    }
+    if num_workers > 0:
+        kwargs["persistent_workers"] = True
+    return DataLoader(**kwargs)
+
+
+def build_binary_split(features_buggy: np.ndarray, features_fixed: np.ndarray, global_indices: np.ndarray) -> Tuple[np.ndarray, np.ndarray, List[Dict[str, Any]]]:
+    x_buggy = build_binary_feature(features_buggy, feature_mode="buggy")
+    x_fixed = build_binary_feature(features_fixed, feature_mode="buggy")
+    y_buggy = np.ones((len(x_buggy),), dtype=np.float32)
+    y_fixed = np.zeros((len(x_fixed),), dtype=np.float32)
+
+    x = np.concatenate([x_buggy, x_fixed], axis=0).astype(np.float32)
+    y = np.concatenate([y_buggy, y_fixed], axis=0).astype(np.float32)
+
+    meta: List[Dict[str, Any]] = []
+    for idx in global_indices:
+        meta.append({"global_index": int(idx), "source": "buggy"})
+    for idx in global_indices:
+        meta.append({"global_index": int(idx), "source": "fixed"})
+    return x, y, meta
+
+
+def load_split_binary_data(
+    backend: str,
+    method: str,
+    split_dir: str,
+    embedding_view: str,
+    file_kwargs: Dict[str, str],
+    online_kwargs: Dict[str, Any],
+) -> Tuple[np.ndarray, np.ndarray, List[Dict[str, Any]]]:
+    if backend == "offline_pt":
+        loaded = load_method_split_embeddings(
+            split_dir,
+            method=method,
+            embedding_view=embedding_view,
+            **file_kwargs,
+        )
+        return build_binary_split(loaded.buggy_emb, loaded.tgt_emb, loaded.global_indices)
+    if backend == "online_checkpoint":
+        loaded = load_online_split_embeddings(
+            checkpoint_path=str(online_kwargs["jepa_checkpoint"]),
+            config_path=str(online_kwargs["jepa_config"]),
+            encoder_mode=str(online_kwargs["encoder_mode"]),
+            indices_dir=str(online_kwargs["indices_dir"]),
+            indices_file=str(online_kwargs["indices_file_by_split"][split_dir]),
+            global_target_dir=str(online_kwargs["global_target_dir"]),
+            global_target_file=str(online_kwargs["global_target_file"]),
+            hf_dataset_name=str(online_kwargs["hf_dataset_name"]),
+            hf_split=str(online_kwargs["hf_split"]),
+            hf_buggy_field=str(online_kwargs["hf_buggy_field"]),
+            hf_fixed_field=str(online_kwargs["hf_fixed_field"]),
+            max_len=int(online_kwargs["max_len"]),
+            batch_size=int(online_kwargs["extract_batch_size"]),
+            num_workers=int(online_kwargs["extract_num_workers"]),
+            device=online_kwargs["device"],
+        )
+        return build_binary_split(loaded.buggy_emb, loaded.tgt_emb, loaded.global_indices)
+    raise ValueError(f"Unsupported backend: {backend}")
+
+
+def compute_binary_metrics(y_true: np.ndarray, y_prob: np.ndarray, threshold: float = 0.5) -> Dict[str, float]:
+    y_pred = (y_prob >= threshold).astype(np.int32)
+    y_true = y_true.astype(np.int32)
+    return {
+        "accuracy": float(accuracy_score(y_true, y_pred)),
+        "precision": float(precision_score(y_true, y_pred, zero_division=0)),
+        "recall": float(recall_score(y_true, y_pred, zero_division=0)),
+        "f1": float(f1_score(y_true, y_pred, zero_division=0)),
+    }
+
+
+def evaluate(
+    model: nn.Module,
+    dataloader: DataLoader,
+    criterion: nn.Module,
+    device: torch.device,
+    threshold: float,
+    split_name: str,
+) -> Dict[str, float]:
+    model.eval()
+    running_loss = 0.0
+    total = 0
+    all_probs: List[np.ndarray] = []
+    all_targets: List[np.ndarray] = []
+
+    with torch.no_grad():
+        for batch in tqdm(dataloader, desc=f"[{split_name}]", leave=False):
+            x, y = batch[:2]
+            x = x.to(device, non_blocking=True)
+            y = y.to(device, non_blocking=True)
+            logits = model(x)
+            loss = criterion(logits, y)
+            probs = torch.sigmoid(logits)
+
+            bs = x.size(0)
+            total += bs
+            running_loss += loss.item() * bs
+            all_probs.append(probs.detach().cpu().numpy())
+            all_targets.append(y.detach().cpu().numpy())
+
+    y_prob = np.concatenate(all_probs, axis=0) if all_probs else np.zeros((0,), dtype=np.float32)
+    y_true = np.concatenate(all_targets, axis=0) if all_targets else np.zeros((0,), dtype=np.float32)
+    metrics = compute_binary_metrics(y_true, y_prob, threshold=threshold)
+    metrics["loss"] = float(running_loss / max(total, 1))
+    return metrics
+
+
+def build_predictions(
+    model: nn.Module,
+    dataloader: DataLoader,
+    device: torch.device,
+    threshold: float,
+) -> List[Dict[str, Any]]:
+    model.eval()
+    outputs: List[Dict[str, Any]] = []
+
+    with torch.no_grad():
+        for x, _, meta_batch in tqdm(dataloader, desc="[Predict]", leave=False):
+            x = x.to(device, non_blocking=True)
+            probs = torch.sigmoid(model(x)).detach().cpu().numpy()
+            global_indices = meta_batch["global_index"]
+            sources = meta_batch["source"]
+            for global_index, source, prob in zip(global_indices, sources, probs):
+                pred_label = int(prob >= threshold)
+                outputs.append(
+                    {
+                        "global_index": int(global_index),
+                        "source": source,
+                        "probability_buggy": float(prob),
+                        "predicted_label": pred_label,
+                        "target_label": 1 if source == "buggy" else 0,
+                    }
+                )
+    return outputs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train binary buggy-vs-fixed classifier probe")
+    parser.add_argument("--backend", type=str, default="offline_pt", choices=["offline_pt", "online_checkpoint"])
+    parser.add_argument("--method", type=str, default="e2", choices=["e1", "e2", "seq_emb"])
+    parser.add_argument("--train-dir", type=str, required=True)
+    parser.add_argument("--val-dir", type=str, required=True)
+    parser.add_argument("--test-dir", type=str, required=True)
+    parser.add_argument("--embedding-view", type=str, default="ctx", choices=["ctx", "tgt", "ctx_tgt"])
+    parser.add_argument("--jepa-checkpoint", type=str, default="")
+    parser.add_argument("--jepa-config", type=str, default="")
+    parser.add_argument("--encoder-mode", type=str, default="same_encoder", choices=["same_encoder", "context_target", "target_target"])
+    parser.add_argument("--indices-dir", type=str, default="")
+    parser.add_argument("--global-target-dir", type=str, default="")
+    parser.add_argument("--global-target-file", type=str, default="global_target_indices.npy")
+    parser.add_argument("--train-indices", type=str, default="train_idx.npy")
+    parser.add_argument("--val-indices", type=str, default="val_idx.npy")
+    parser.add_argument("--test-indices", type=str, default="test_idx.npy")
+    parser.add_argument("--hf-dataset-name", type=str, default="")
+    parser.add_argument("--hf-split", type=str, default="")
+    parser.add_argument("--hf-buggy-field", type=str, default="")
+    parser.add_argument("--hf-fixed-field", type=str, default="")
+    parser.add_argument("--max-len", type=int, default=512)
+    parser.add_argument("--extract-batch-size", type=int, default=128)
+    parser.add_argument("--extract-num-workers", type=int, default=4)
+    parser.add_argument("--global-indices-key", type=str, default="global_indices")
+    parser.add_argument("--buggy-file-name", type=str, default="")
+    parser.add_argument("--buggy-key", type=str, default="")
+    parser.add_argument("--pred-file-name", type=str, default="")
+    parser.add_argument("--pred-key", type=str, default="")
+    parser.add_argument("--tgt-file-name", type=str, default="")
+    parser.add_argument("--tgt-key", type=str, default="")
+    parser.add_argument("--buggy-ctx-file-name", type=str, default="")
+    parser.add_argument("--buggy-ctx-key", type=str, default="")
+    parser.add_argument("--fixed-ctx-file-name", type=str, default="")
+    parser.add_argument("--fixed-ctx-key", type=str, default="")
+    parser.add_argument("--buggy-tgt-file-name", type=str, default="")
+    parser.add_argument("--buggy-tgt-key", type=str, default="")
+    parser.add_argument("--fixed-tgt-file-name", type=str, default="")
+    parser.add_argument("--fixed-tgt-key", type=str, default="")
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--epochs", type=int, default=20)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--hidden-dim", type=int, default=512)
+    parser.add_argument("--dropout", type=float, default=0.3)
+    parser.add_argument("--threshold", type=float, default=0.5)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-dir", type=str, required=True)
+    parser.add_argument("--use-wandb", type=int, default=0)
+    parser.add_argument("--wandb-project", type=str, default="CodeRepair_JEPA_downstream")
+    parser.add_argument("--wandb-entity", type=str, default="assert-kth")
+    parser.add_argument("--wandb-run-name", type=str, default="")
+    parser.add_argument("--wandb-group", type=str, default="bug_detection")
+    parser.add_argument("--wandb-id", type=str, default="")
+    args = parser.parse_args()
+
+    Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+    seed_everything(args.seed)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    file_kwargs = {
+        "global_indices_key": args.global_indices_key,
+        "buggy_file_name": args.buggy_file_name,
+        "buggy_key": args.buggy_key,
+        "pred_file_name": args.pred_file_name,
+        "pred_key": args.pred_key,
+        "tgt_file_name": args.tgt_file_name,
+        "tgt_key": args.tgt_key,
+        "buggy_ctx_file_name": args.buggy_ctx_file_name,
+        "buggy_ctx_key": args.buggy_ctx_key,
+        "fixed_ctx_file_name": args.fixed_ctx_file_name,
+        "fixed_ctx_key": args.fixed_ctx_key,
+        "buggy_tgt_file_name": args.buggy_tgt_file_name,
+        "buggy_tgt_key": args.buggy_tgt_key,
+        "fixed_tgt_file_name": args.fixed_tgt_file_name,
+        "fixed_tgt_key": args.fixed_tgt_key,
+    }
+    online_kwargs = {
+        "jepa_checkpoint": args.jepa_checkpoint,
+        "jepa_config": args.jepa_config,
+        "encoder_mode": args.encoder_mode,
+        "indices_dir": args.indices_dir,
+        "global_target_dir": args.global_target_dir,
+        "global_target_file": args.global_target_file,
+        "hf_dataset_name": args.hf_dataset_name,
+        "hf_split": args.hf_split,
+        "hf_buggy_field": args.hf_buggy_field,
+        "hf_fixed_field": args.hf_fixed_field,
+        "max_len": args.max_len,
+        "extract_batch_size": args.extract_batch_size,
+        "extract_num_workers": args.extract_num_workers,
+        "device": device,
+        "indices_file_by_split": {
+            args.train_dir: args.train_indices,
+            args.val_dir: args.val_indices,
+            args.test_dir: args.test_indices,
+        },
+    }
+
+    train_x, train_y, _ = load_split_binary_data(args.backend, args.method, args.train_dir, args.embedding_view, file_kwargs, online_kwargs)
+    val_x, val_y, _ = load_split_binary_data(args.backend, args.method, args.val_dir, args.embedding_view, file_kwargs, online_kwargs)
+    test_x, test_y, test_meta = load_split_binary_data(args.backend, args.method, args.test_dir, args.embedding_view, file_kwargs, online_kwargs)
+
+    train_ds = BinaryFeatureDataset(train_x, train_y)
+    val_ds = BinaryFeatureDataset(val_x, val_y)
+    test_ds = BinaryFeatureDataset(test_x, test_y)
+    pred_test_ds = BinaryFeatureDataset(test_x, test_y, meta=test_meta)
+
+    train_dl = make_dataloader(train_ds, args.batch_size, True, args.num_workers)
+    val_dl = make_dataloader(val_ds, args.batch_size, False, args.num_workers)
+    test_dl = make_dataloader(test_ds, args.batch_size, False, args.num_workers)
+    pred_test_dl = make_dataloader(pred_test_ds, args.batch_size, False, args.num_workers)
+
+    input_dim = int(train_x.shape[1])
+    model = BinaryMLP(input_dim, hidden_dim=args.hidden_dim, dropout=args.dropout).to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+    criterion = nn.BCEWithLogitsLoss()
+
+    best_val_f1 = -1.0
+    best_epoch = -1
+    history: List[Dict[str, Any]] = []
+    best_ckpt_path = Path(args.output_dir) / "best_model.pt"
+    last_ckpt_path = Path(args.output_dir) / "last_model.pt"
+
+    if args.use_wandb and wandb is not None:
+        wandb.init(
+            project=args.wandb_project or None,
+            entity=args.wandb_entity or None,
+            name=args.wandb_run_name or None,
+            group=args.wandb_group or None,
+            id=args.wandb_id or None,
+            resume="allow" if args.wandb_id else None,
+            config={
+                "backend": args.backend,
+                "method": args.method,
+                "embedding_view": args.embedding_view,
+                "batch_size": args.batch_size,
+                "epochs": args.epochs,
+                "lr": args.lr,
+                "hidden_dim": args.hidden_dim,
+                "dropout": args.dropout,
+            },
+        )
+
+    for epoch in range(1, args.epochs + 1):
+        model.train()
+        running_loss = 0.0
+        total = 0
+        for x, y in tqdm(train_dl, desc=f"[Train {epoch}/{args.epochs}]", leave=False):
+            x = x.to(device, non_blocking=True)
+            y = y.to(device, non_blocking=True)
+
+            optimizer.zero_grad(set_to_none=True)
+            logits = model(x)
+            loss = criterion(logits, y)
+            loss.backward()
+            optimizer.step()
+
+            bs = x.size(0)
+            total += bs
+            running_loss += loss.item() * bs
+
+        train_loss = float(running_loss / max(total, 1))
+        val_metrics = evaluate(model, val_dl, criterion, device, args.threshold, "Val")
+
+        record = {
+            "epoch": epoch,
+            "train_loss": train_loss,
+            "val_loss": val_metrics["loss"],
+            "val_accuracy": val_metrics["accuracy"],
+            "val_precision": val_metrics["precision"],
+            "val_recall": val_metrics["recall"],
+            "val_f1": val_metrics["f1"],
+        }
+        history.append(record)
+
+        print(
+            f"Epoch {epoch:03d} | train={train_loss:.4f} "
+            f"val_acc={val_metrics['accuracy']:.4f} val_f1={val_metrics['f1']:.4f}"
+        )
+
+        if args.use_wandb and wandb is not None and wandb.run is not None:
+            wandb.log(
+                {
+                    "epoch": epoch,
+                    "train/loss": train_loss,
+                    "val/loss": val_metrics["loss"],
+                    "val/accuracy": val_metrics["accuracy"],
+                    "val/precision": val_metrics["precision"],
+                    "val/recall": val_metrics["recall"],
+                    "val/f1": val_metrics["f1"],
+                },
+                step=epoch,
+            )
+
+        ckpt = {
+            "model": model.state_dict(),
+            "input_dim": input_dim,
+            "threshold": args.threshold,
+            "epoch": epoch,
+            "backend": args.backend,
+            "method": args.method,
+            "embedding_view": args.embedding_view,
+            "hidden_dim": args.hidden_dim,
+            "dropout": args.dropout,
+        }
+        torch.save(ckpt, last_ckpt_path)
+
+        if val_metrics["f1"] > best_val_f1:
+            best_val_f1 = val_metrics["f1"]
+            best_epoch = epoch
+            ckpt["best_val_f1"] = best_val_f1
+            torch.save(ckpt, best_ckpt_path)
+
+    save_json(history, Path(args.output_dir) / "history.json")
+
+    best_ckpt = torch.load(best_ckpt_path, map_location="cpu", weights_only=False)
+    best_model = BinaryMLP(
+        best_ckpt["input_dim"],
+        hidden_dim=int(best_ckpt.get("hidden_dim", args.hidden_dim)),
+        dropout=float(best_ckpt.get("dropout", args.dropout)),
+    )
+    best_model.load_state_dict(best_ckpt["model"])
+    best_model = best_model.to(device)
+
+    val_metrics = evaluate(best_model, val_dl, criterion, device, args.threshold, "Val-best")
+    test_metrics = evaluate(best_model, test_dl, criterion, device, args.threshold, "Test-best")
+    test_predictions = build_predictions(best_model, pred_test_dl, device, args.threshold)
+
+    final_metrics = {
+        "best_val_f1": best_val_f1,
+        "best_epoch": best_epoch,
+        "val": val_metrics,
+        "test": test_metrics,
+    }
+    save_json(final_metrics, Path(args.output_dir) / "final_metrics.json")
+    save_json(test_predictions, Path(args.output_dir) / "test_predictions.json")
+
+    if args.use_wandb and wandb is not None and wandb.run is not None:
+        wandb.run.summary["best_val_f1"] = best_val_f1
+        wandb.run.summary["best_epoch"] = best_epoch
+        wandb.run.summary["test_accuracy"] = test_metrics["accuracy"]
+        wandb.run.summary["test_f1"] = test_metrics["f1"]
+        wandb.finish()
+
+    print(json.dumps(final_metrics, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/JEPA_downstream/src/common/__init__.py
+++ b/JEPA_downstream/src/common/__init__.py
@@ -1,0 +1,54 @@
+from .features import (
+    BINARY_FEATURE_MODES,
+    EDIT_TYPE_FEATURE_MODES,
+    build_binary_feature,
+    build_edit_type_feature,
+    infer_binary_input_dim,
+    infer_edit_type_input_dim,
+)
+from .io import (
+    DEFAULT_E1_FILES,
+    DEFAULT_E2_FILES,
+    LoadedSplitEmbeddings,
+    load_method_split_embeddings,
+    load_multilabel_targets,
+)
+from .online_extractors import (
+    ddp_cleanup,
+    ddp_enabled,
+    ddp_local_rank,
+    ddp_rank,
+    ddp_setup,
+    ddp_world_size,
+    is_main_process,
+    load_online_split_embeddings,
+)
+from .models import BinaryMLP, MultiLabelMLP
+from .utils import ensure_dir, save_json, seed_everything
+
+__all__ = [
+    "BINARY_FEATURE_MODES",
+    "EDIT_TYPE_FEATURE_MODES",
+    "BinaryMLP",
+    "DEFAULT_E1_FILES",
+    "DEFAULT_E2_FILES",
+    "LoadedSplitEmbeddings",
+    "MultiLabelMLP",
+    "build_binary_feature",
+    "build_edit_type_feature",
+    "ddp_cleanup",
+    "ddp_enabled",
+    "ddp_local_rank",
+    "ddp_rank",
+    "ddp_setup",
+    "ddp_world_size",
+    "ensure_dir",
+    "infer_binary_input_dim",
+    "infer_edit_type_input_dim",
+    "load_method_split_embeddings",
+    "load_multilabel_targets",
+    "is_main_process",
+    "load_online_split_embeddings",
+    "save_json",
+    "seed_everything",
+]

--- a/JEPA_downstream/src/common/features.py
+++ b/JEPA_downstream/src/common/features.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+EDIT_TYPE_FEATURE_MODES = ("tgt_minus_buggy", "tgt", "buggy")
+BINARY_FEATURE_MODES = ("buggy",)
+
+
+def build_edit_type_feature(buggy_emb: np.ndarray, tgt_emb: np.ndarray, feature_mode: str) -> np.ndarray:
+    if feature_mode == "tgt_minus_buggy":
+        x = tgt_emb - buggy_emb
+    elif feature_mode == "tgt":
+        x = tgt_emb
+    elif feature_mode == "buggy":
+        x = buggy_emb
+    else:
+        raise ValueError(f"Unsupported edit_type feature_mode: {feature_mode}")
+    return np.asarray(x, dtype=np.float32)
+
+
+def build_binary_feature(buggy_emb: np.ndarray, feature_mode: str) -> np.ndarray:
+    if feature_mode != "buggy":
+        raise ValueError(f"Unsupported bug_detection feature_mode: {feature_mode}")
+    return np.asarray(buggy_emb, dtype=np.float32)
+
+
+def infer_edit_type_input_dim(feature_mode: str, emb_dim: int) -> int:
+    if feature_mode in EDIT_TYPE_FEATURE_MODES:
+        return int(emb_dim)
+    raise ValueError(f"Unsupported edit_type feature_mode: {feature_mode}")
+
+
+def infer_binary_input_dim(feature_mode: str, emb_dim: int) -> int:
+    if feature_mode in BINARY_FEATURE_MODES:
+        return int(emb_dim)
+    raise ValueError(f"Unsupported bug_detection feature_mode: {feature_mode}")

--- a/JEPA_downstream/src/common/io.py
+++ b/JEPA_downstream/src/common/io.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+from datasets import load_dataset
+
+
+DEFAULT_E1_FILES = {
+    "buggy_file_name": "z_buggy.pt",
+    "buggy_key": "z_buggy",
+    "pred_file_name": "z_pred.pt",
+    "pred_key": "z_pred",
+    "tgt_file_name": "z_gt.pt",
+    "tgt_key": "z_gt",
+}
+
+DEFAULT_E2_FILES = {
+    "buggy_file_name": "z_ctx.pt",
+    "buggy_key": "z_ctx",
+    "pred_file_name": "z_pred.pt",
+    "pred_key": "z_pred",
+    "tgt_file_name": "z_tgt.pt",
+    "tgt_key": "z_tgt",
+}
+
+DEFAULT_POOLED_FILES = {
+    "buggy_ctx_file_name": "buggy_ctx.pt",
+    "buggy_ctx_key": "emb",
+    "fixed_ctx_file_name": "fixed_ctx.pt",
+    "fixed_ctx_key": "emb",
+    "buggy_tgt_file_name": "buggy_tgt.pt",
+    "buggy_tgt_key": "emb",
+    "fixed_tgt_file_name": "fixed_tgt.pt",
+    "fixed_tgt_key": "emb",
+    "pred_file_name": "pred.pt",
+    "pred_key": "emb",
+}
+
+
+@dataclass
+class LoadedSplitEmbeddings:
+    buggy_emb: np.ndarray
+    pred_emb: np.ndarray
+    tgt_emb: np.ndarray
+    global_indices: np.ndarray
+
+
+def to_numpy(x: Any) -> np.ndarray:
+    if isinstance(x, np.ndarray):
+        return x
+    if torch.is_tensor(x):
+        return x.detach().cpu().numpy()
+    return np.asarray(x)
+
+
+def load_tensor_file(path: str) -> Any:
+    suffix = Path(path).suffix.lower()
+    if suffix in {".pt", ".pth"}:
+        return torch.load(path, map_location="cpu", weights_only=False)
+    raise ValueError(f"Unsupported file suffix for tensor file: {path}")
+
+
+def extract_dict_array(data: Any, path: str, key: str, fallback_keys: Optional[Sequence[str]] = None) -> np.ndarray:
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must be a dict, got: {type(data)}")
+    candidate_keys = [key]
+    if fallback_keys is not None:
+        candidate_keys.extend(str(k) for k in fallback_keys)
+    for candidate in candidate_keys:
+        if candidate in data:
+            return to_numpy(data[candidate])
+    raise KeyError(
+        f"Missing keys={candidate_keys} in {path}. Available keys: {list(data.keys())}"
+    )
+
+
+def squeeze_embedding_array(arr: np.ndarray, name: str) -> np.ndarray:
+    arr = np.asarray(arr)
+    if arr.ndim == 3 and arr.shape[1] == 1:
+        arr = arr[:, 0, :]
+    if arr.ndim != 2:
+        raise ValueError(f"{name} must have shape [N, D] or [N, 1, D], got: {arr.shape}")
+    return arr.astype(np.float32)
+
+
+def resolve_method_files(method: str) -> Dict[str, str]:
+    method_name = str(method).lower()
+    if method_name == "e1":
+        return dict(DEFAULT_E1_FILES)
+    if method_name == "e2":
+        return dict(DEFAULT_E2_FILES)
+    if method_name in {"seq", "seq_emb"}:
+        return dict(DEFAULT_POOLED_FILES)
+    raise ValueError(f"Unsupported offline method: {method}")
+
+
+def build_file_spec(
+    method: str,
+    buggy_file_name: str = "",
+    buggy_key: str = "",
+    pred_file_name: str = "",
+    pred_key: str = "",
+    tgt_file_name: str = "",
+    tgt_key: str = "",
+    buggy_ctx_file_name: str = "",
+    buggy_ctx_key: str = "",
+    fixed_ctx_file_name: str = "",
+    fixed_ctx_key: str = "",
+    buggy_tgt_file_name: str = "",
+    buggy_tgt_key: str = "",
+    fixed_tgt_file_name: str = "",
+    fixed_tgt_key: str = "",
+) -> Dict[str, str]:
+    spec = resolve_method_files(method)
+    method_name = str(method).lower()
+    if method_name in {"seq", "seq_emb"}:
+        if buggy_file_name:
+            spec["buggy_ctx_file_name"] = buggy_file_name
+        if buggy_key:
+            spec["buggy_ctx_key"] = buggy_key
+        if tgt_file_name:
+            spec["fixed_ctx_file_name"] = tgt_file_name
+        if tgt_key:
+            spec["fixed_ctx_key"] = tgt_key
+        if buggy_ctx_file_name:
+            spec["buggy_ctx_file_name"] = buggy_ctx_file_name
+        if buggy_ctx_key:
+            spec["buggy_ctx_key"] = buggy_ctx_key
+        if fixed_ctx_file_name:
+            spec["fixed_ctx_file_name"] = fixed_ctx_file_name
+        if fixed_ctx_key:
+            spec["fixed_ctx_key"] = fixed_ctx_key
+        if buggy_tgt_file_name:
+            spec["buggy_tgt_file_name"] = buggy_tgt_file_name
+        if buggy_tgt_key:
+            spec["buggy_tgt_key"] = buggy_tgt_key
+        if fixed_tgt_file_name:
+            spec["fixed_tgt_file_name"] = fixed_tgt_file_name
+        if fixed_tgt_key:
+            spec["fixed_tgt_key"] = fixed_tgt_key
+        if pred_file_name:
+            spec["pred_file_name"] = pred_file_name
+        if pred_key:
+            spec["pred_key"] = pred_key
+        return spec
+    if buggy_file_name:
+        spec["buggy_file_name"] = buggy_file_name
+    if buggy_key:
+        spec["buggy_key"] = buggy_key
+    if pred_file_name:
+        spec["pred_file_name"] = pred_file_name
+    if pred_key:
+        spec["pred_key"] = pred_key
+    if tgt_file_name:
+        spec["tgt_file_name"] = tgt_file_name
+    if tgt_key:
+        spec["tgt_key"] = tgt_key
+    return spec
+
+
+def _extract_embedding_with_global_indices(
+    path: Path,
+    emb_key: str,
+    global_indices_key: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    data = load_tensor_file(str(path))
+    emb = squeeze_embedding_array(
+        extract_dict_array(data, str(path), emb_key, fallback_keys=["emb"]),
+        f"{path.parent.name}/{path.stem}",
+    )
+    gidx = extract_dict_array(data, str(path), global_indices_key).astype(np.int64)
+    if len(emb) != len(gidx):
+        raise ValueError(f"{path}: global_indices length does not match embeddings")
+    return emb, gidx
+
+
+def _resolve_view_file_pair(
+    split_path: Path,
+    spec: Dict[str, str],
+    embedding_view: str,
+) -> tuple[Path, str, Path, str]:
+    view = str(embedding_view).lower()
+    if view == "ctx":
+        return (
+            split_path / spec["buggy_ctx_file_name"],
+            spec["buggy_ctx_key"],
+            split_path / spec["fixed_ctx_file_name"],
+            spec["fixed_ctx_key"],
+        )
+    if view == "tgt":
+        return (
+            split_path / spec["buggy_tgt_file_name"],
+            spec["buggy_tgt_key"],
+            split_path / spec["fixed_tgt_file_name"],
+            spec["fixed_tgt_key"],
+        )
+    if view == "ctx_tgt":
+        return (
+            split_path / spec["buggy_ctx_file_name"],
+            spec["buggy_ctx_key"],
+            split_path / spec["fixed_tgt_file_name"],
+            spec["fixed_tgt_key"],
+        )
+    raise ValueError(f"Unsupported embedding_view: {embedding_view}")
+
+
+def _supports_pooled_view_files(split_path: Path) -> bool:
+    return all(
+        (split_path / name).exists()
+        for name in ["buggy_ctx.pt", "fixed_ctx.pt", "buggy_tgt.pt", "fixed_tgt.pt", "pred.pt"]
+    )
+
+
+def load_method_split_embeddings(
+    split_dir: str,
+    method: str,
+    embedding_view: str = "ctx",
+    global_indices_key: str = "global_indices",
+    buggy_file_name: str = "",
+    buggy_key: str = "",
+    pred_file_name: str = "",
+    pred_key: str = "",
+    tgt_file_name: str = "",
+    tgt_key: str = "",
+    buggy_ctx_file_name: str = "",
+    buggy_ctx_key: str = "",
+    fixed_ctx_file_name: str = "",
+    fixed_ctx_key: str = "",
+    buggy_tgt_file_name: str = "",
+    buggy_tgt_key: str = "",
+    fixed_tgt_file_name: str = "",
+    fixed_tgt_key: str = "",
+) -> LoadedSplitEmbeddings:
+    split_path = Path(split_dir)
+    spec = build_file_spec(
+        method,
+        buggy_file_name=buggy_file_name,
+        buggy_key=buggy_key,
+        pred_file_name=pred_file_name,
+        pred_key=pred_key,
+        tgt_file_name=tgt_file_name,
+        tgt_key=tgt_key,
+        buggy_ctx_file_name=buggy_ctx_file_name,
+        buggy_ctx_key=buggy_ctx_key,
+        fixed_ctx_file_name=fixed_ctx_file_name,
+        fixed_ctx_key=fixed_ctx_key,
+        buggy_tgt_file_name=buggy_tgt_file_name,
+        buggy_tgt_key=buggy_tgt_key,
+        fixed_tgt_file_name=fixed_tgt_file_name,
+        fixed_tgt_key=fixed_tgt_key,
+    )
+    method_name = str(method).lower()
+
+    if method_name in {"seq", "seq_emb"} or (method_name == "e2" and _supports_pooled_view_files(split_path)):
+        pooled_spec = dict(DEFAULT_POOLED_FILES)
+        if method_name in {"seq", "seq_emb"}:
+            pooled_spec.update(spec)
+        buggy_path, buggy_key_name, tgt_path, tgt_key_name = _resolve_view_file_pair(
+            split_path, pooled_spec, embedding_view
+        )
+        pred_path = split_path / pooled_spec["pred_file_name"]
+        if not buggy_path.exists():
+            raise FileNotFoundError(f"Missing buggy embedding file: {buggy_path}")
+        if not tgt_path.exists():
+            raise FileNotFoundError(f"Missing target embedding file: {tgt_path}")
+        if not pred_path.exists():
+            raise FileNotFoundError(f"Missing pred embedding file: {pred_path}")
+
+        buggy_emb, buggy_global = _extract_embedding_with_global_indices(
+            buggy_path, buggy_key_name, global_indices_key
+        )
+        tgt_emb, tgt_global = _extract_embedding_with_global_indices(
+            tgt_path, tgt_key_name, global_indices_key
+        )
+        pred_emb, pred_global = _extract_embedding_with_global_indices(
+            pred_path, pooled_spec["pred_key"], global_indices_key
+        )
+
+        num_samples = len(buggy_emb)
+        if len(tgt_emb) != num_samples or len(pred_emb) != num_samples:
+            raise ValueError(
+                f"{split_dir}: embedding size mismatch: buggy={len(buggy_emb)} pred={len(pred_emb)} tgt={len(tgt_emb)}"
+            )
+        if not np.array_equal(buggy_global, pred_global) or not np.array_equal(buggy_global, tgt_global):
+            raise ValueError(f"{split_dir}: global_indices differ across embedding files")
+
+        return LoadedSplitEmbeddings(
+            buggy_emb=buggy_emb,
+            pred_emb=pred_emb,
+            tgt_emb=tgt_emb,
+            global_indices=buggy_global,
+        )
+
+    buggy_path = split_path / spec["buggy_file_name"]
+    pred_path = split_path / spec["pred_file_name"]
+    tgt_path = split_path / spec["tgt_file_name"]
+
+    if not buggy_path.exists():
+        raise FileNotFoundError(f"Missing buggy embedding file: {buggy_path}")
+    if not pred_path.exists():
+        raise FileNotFoundError(f"Missing pred embedding file: {pred_path}")
+    if not tgt_path.exists():
+        raise FileNotFoundError(f"Missing target embedding file: {tgt_path}")
+
+    buggy_data = load_tensor_file(str(buggy_path))
+    pred_data = load_tensor_file(str(pred_path))
+    tgt_data = load_tensor_file(str(tgt_path))
+
+    buggy_emb = squeeze_embedding_array(
+        extract_dict_array(buggy_data, str(buggy_path), spec["buggy_key"], fallback_keys=["emb"]),
+        f"{split_path.name}/buggy_emb",
+    )
+    pred_emb = squeeze_embedding_array(
+        extract_dict_array(pred_data, str(pred_path), spec["pred_key"], fallback_keys=["emb"]),
+        f"{split_path.name}/pred_emb",
+    )
+    tgt_emb = squeeze_embedding_array(
+        extract_dict_array(tgt_data, str(tgt_path), spec["tgt_key"], fallback_keys=["emb"]),
+        f"{split_path.name}/tgt_emb",
+    )
+
+    buggy_global = extract_dict_array(buggy_data, str(buggy_path), global_indices_key).astype(np.int64)
+    pred_global = extract_dict_array(pred_data, str(pred_path), global_indices_key).astype(np.int64)
+    tgt_global = extract_dict_array(tgt_data, str(tgt_path), global_indices_key).astype(np.int64)
+
+    num_samples = len(buggy_emb)
+    if len(pred_emb) != num_samples or len(tgt_emb) != num_samples:
+        raise ValueError(
+            f"{split_dir}: embedding size mismatch: buggy={len(buggy_emb)} pred={len(pred_emb)} tgt={len(tgt_emb)}"
+        )
+    if len(buggy_global) != num_samples or len(pred_global) != num_samples or len(tgt_global) != num_samples:
+        raise ValueError(f"{split_dir}: global_indices length does not match embeddings")
+    if not np.array_equal(buggy_global, pred_global) or not np.array_equal(buggy_global, tgt_global):
+        raise ValueError(f"{split_dir}: global_indices differ across embedding files")
+
+    return LoadedSplitEmbeddings(
+        buggy_emb=buggy_emb,
+        pred_emb=pred_emb,
+        tgt_emb=tgt_emb,
+        global_indices=buggy_global,
+    )
+
+
+def normalize_label_item(x: Any) -> Any:
+    if isinstance(x, np.generic):
+        return x.item()
+    return x
+
+
+def build_multihot_from_label_lists(
+    label_lists: Sequence[Sequence[Any]],
+    label_to_idx: Optional[Dict[str, int]] = None,
+) -> Tuple[np.ndarray, Dict[str, int], Dict[int, str]]:
+    cleaned: List[List[Any]] = []
+    for labels in label_lists:
+        if labels is None:
+            cleaned.append([])
+        else:
+            cleaned.append([normalize_label_item(v) for v in labels])
+
+    if label_to_idx is None:
+        all_labels = sorted({str(label) for sample in cleaned for label in sample})
+        label_to_idx = {label: idx for idx, label in enumerate(all_labels)}
+
+    idx_to_label = {idx: label for label, idx in label_to_idx.items()}
+    y = np.zeros((len(cleaned), len(label_to_idx)), dtype=np.float32)
+    for i, labels in enumerate(cleaned):
+        for label in labels:
+            key = str(label)
+            if key in label_to_idx:
+                y[i, label_to_idx[key]] = 1.0
+    return y, label_to_idx, idx_to_label
+
+
+def load_label_lists_for_global_indices(
+    dataset: Any,
+    global_indices: np.ndarray,
+    hf_label_field: str,
+    split_name: str,
+) -> List[List[Any]]:
+    if len(global_indices) == 0:
+        return []
+
+    global_indices = global_indices.astype(np.int64)
+    max_idx = int(np.max(global_indices))
+    if max_idx >= len(dataset):
+        raise IndexError(
+            f"{split_name}: requested max dataset index {max_idx}, but dataset length is {len(dataset)}."
+        )
+
+    selected = dataset.select(global_indices.tolist())
+    raw_label_lists = selected[hf_label_field]
+
+    output: List[List[Any]] = []
+    for labels in raw_label_lists:
+        if labels is None:
+            output.append([])
+        else:
+            output.append([normalize_label_item(v) for v in labels])
+    return output
+
+
+def load_multilabel_targets(
+    global_indices: np.ndarray,
+    hf_dataset_name: str,
+    hf_split: str,
+    hf_label_field: str,
+    split_name: str,
+    label_to_idx: Optional[Dict[str, int]] = None,
+) -> Tuple[np.ndarray, Dict[str, int], Dict[int, str]]:
+    dataset = load_dataset(hf_dataset_name, split=hf_split)
+    label_lists = load_label_lists_for_global_indices(dataset, global_indices, hf_label_field, split_name)
+    return build_multihot_from_label_lists(label_lists, label_to_idx=label_to_idx)

--- a/JEPA_downstream/src/common/models.py
+++ b/JEPA_downstream/src/common/models.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class MultiLabelMLP(nn.Module):
+    def __init__(self, input_dim: int, output_dim: int, hidden_dim: int = 512, dropout: float = 0.3) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_dim, output_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class BinaryMLP(nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int = 512, dropout: float = 0.3) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x).squeeze(-1)

--- a/JEPA_downstream/src/common/online_extractors.py
+++ b/JEPA_downstream/src/common/online_extractors.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import sys
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import numpy as np
+import torch
+from datasets import load_dataset
+from torch.utils.data import DataLoader, Dataset
+from tqdm.auto import tqdm
+from transformers import AutoTokenizer
+
+from .io import LoadedSplitEmbeddings
+
+
+JEPA_REGION_SRC = Path(__file__).resolve().parents[3] / "JEPA_region" / "src"
+if str(JEPA_REGION_SRC) not in sys.path:
+    sys.path.insert(0, str(JEPA_REGION_SRC))
+
+from models import build_encoder, load_encoder_tunable_state  # type: ignore  # noqa: E402
+from utils import load_yaml  # type: ignore  # noqa: E402
+
+
+class IndexedCodeDataset(Dataset):
+    def __init__(self, dataset: Any, global_indices: np.ndarray, buggy_field: str, fixed_field: str) -> None:
+        self.dataset = dataset
+        self.global_indices = global_indices.astype(np.int64)
+        self.buggy_field = str(buggy_field)
+        self.fixed_field = str(fixed_field)
+
+    def __len__(self) -> int:
+        return len(self.global_indices)
+
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        sample = self.dataset[int(self.global_indices[idx])]
+        return {
+            "buggy": str(sample.get(self.buggy_field, "") or ""),
+            "fixed": str(sample.get(self.fixed_field, "") or ""),
+            "global_index": int(self.global_indices[idx]),
+        }
+
+
+class TokenizingCollator:
+    def __init__(self, tokenizer, max_len: int):
+        self.tokenizer = tokenizer
+        self.max_len = int(max_len)
+
+    def __call__(self, batch):
+        buggy = [item["buggy"] for item in batch]
+        fixed = [item["fixed"] for item in batch]
+        global_indices = torch.tensor([item["global_index"] for item in batch], dtype=torch.long)
+        tok_buggy = self.tokenizer(
+            buggy,
+            padding=True,
+            truncation=True,
+            max_length=self.max_len,
+            return_tensors="pt",
+        )
+        tok_fixed = self.tokenizer(
+            fixed,
+            padding=True,
+            truncation=True,
+            max_length=self.max_len,
+            return_tensors="pt",
+        )
+        return tok_buggy, tok_fixed, global_indices
+
+
+def load_jepa_runtime_cfg(ckpt: Dict[str, Any], config_path: str = "") -> Dict[str, Any]:
+    if config_path:
+        return load_yaml(config_path)
+    cfg = ckpt.get("cfg")
+    if not isinstance(cfg, dict):
+        raise ValueError("JEPA checkpoint is missing embedded cfg. Please provide --jepa-config.")
+    return cfg
+
+
+def load_indices(indices_dir: str, filename: str) -> np.ndarray:
+    return np.load(str(Path(indices_dir) / filename))
+
+
+def ddp_enabled() -> bool:
+    return torch.distributed.is_available() and torch.distributed.is_initialized()
+
+
+def ddp_rank() -> int:
+    return torch.distributed.get_rank() if ddp_enabled() else 0
+
+
+def ddp_world_size() -> int:
+    return torch.distributed.get_world_size() if ddp_enabled() else 1
+
+
+def ddp_local_rank() -> int:
+    return int(os.environ.get("LOCAL_RANK", "0"))
+
+
+def ddp_setup(backend: str = "nccl") -> None:
+    if ddp_enabled():
+        return
+    if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
+        if torch.cuda.is_available():
+            torch.cuda.set_device(ddp_local_rank())
+        torch.distributed.init_process_group(backend=backend)
+
+
+def ddp_cleanup() -> None:
+    if ddp_enabled():
+        torch.distributed.destroy_process_group()
+
+
+def is_main_process() -> bool:
+    return ddp_rank() == 0
+
+
+def to_device(batch: Dict[str, torch.Tensor], device: torch.device) -> Dict[str, torch.Tensor]:
+    return {k: v.to(device, non_blocking=True) for k, v in batch.items()}
+
+
+def masked_mean_pool(hidden: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+    mask = attention_mask.to(dtype=hidden.dtype).unsqueeze(-1)
+    summed = (hidden * mask).sum(dim=1)
+    denom = mask.sum(dim=1).clamp_min(1.0)
+    return summed / denom
+
+
+def _load_encoder_from_ckpt(
+    cfg: Dict[str, Any],
+    ckpt: Dict[str, Any],
+    role: str,
+    device: torch.device,
+):
+    encoder, _ = build_encoder(cfg, device=device)
+    if role == "ctx":
+        if "enc_ctx" in ckpt:
+            encoder.load_state_dict(ckpt["enc_ctx"], strict=True)
+        elif "enc_ctx_tunable" in ckpt:
+            load_encoder_tunable_state(encoder, ckpt["enc_ctx_tunable"], strict=False)
+        else:
+            raise KeyError("Checkpoint is missing context encoder weights.")
+    elif role == "tgt":
+        if "enc_tgt" in ckpt:
+            encoder.load_state_dict(ckpt["enc_tgt"], strict=True)
+        elif "enc_tgt_tunable" in ckpt:
+            load_encoder_tunable_state(encoder, ckpt["enc_tgt_tunable"], strict=False)
+        elif "enc_ctx" in ckpt:
+            encoder.load_state_dict(ckpt["enc_ctx"], strict=True)
+        elif "enc_ctx_tunable" in ckpt:
+            load_encoder_tunable_state(encoder, ckpt["enc_ctx_tunable"], strict=False)
+        else:
+            raise KeyError("Checkpoint is missing target encoder weights.")
+    else:
+        raise ValueError(f"Unknown encoder role: {role}")
+    encoder.eval()
+    for p in encoder.parameters():
+        p.requires_grad = False
+    return encoder
+
+
+@torch.no_grad()
+def load_online_split_embeddings(
+    checkpoint_path: str,
+    config_path: str,
+    encoder_mode: str,
+    indices_dir: str,
+    indices_file: str,
+    global_target_dir: str,
+    global_target_file: str = "global_target_indices.npy",
+    hf_dataset_name: str = "",
+    hf_split: str = "",
+    hf_buggy_field: str = "",
+    hf_fixed_field: str = "",
+    max_len: int = 512,
+    batch_size: int = 128,
+    num_workers: int = 4,
+    device: Optional[torch.device] = None,
+) -> LoadedSplitEmbeddings:
+    ddp_setup("nccl" if torch.cuda.is_available() else "gloo")
+    if torch.cuda.is_available():
+        device = device or torch.device("cuda", ddp_local_rank())
+    else:
+        device = device or torch.device("cpu")
+    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    cfg = load_jepa_runtime_cfg(ckpt, config_path=config_path)
+
+    dataset_name = hf_dataset_name or cfg["data"]["hf"]["dataset_id"]
+    dataset_split = hf_split or cfg["data"]["hf"].get("split", "train")
+    buggy_field = hf_buggy_field or cfg["data"]["hf"]["fields"]["buggy"]
+    fixed_field = hf_fixed_field or cfg["data"]["hf"]["fields"]["fixed"]
+    max_length = int(max_len or cfg["encoder"]["max_len"])
+
+    split_idx = load_indices(indices_dir, indices_file)
+    global_target_idx = load_indices(global_target_dir, global_target_file)
+    global_indices = global_target_idx[split_idx]
+
+    world = ddp_world_size()
+    rank = ddp_rank()
+    sharded_global_indices = global_indices[rank::world]
+
+    dataset = load_dataset(dataset_name, split=dataset_split)
+    tokenizer = AutoTokenizer.from_pretrained(cfg["encoder"]["name"], use_fast=True)
+    ds = IndexedCodeDataset(dataset, sharded_global_indices, buggy_field, fixed_field)
+    dl = DataLoader(
+        ds,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=torch.cuda.is_available(),
+        collate_fn=TokenizingCollator(tokenizer, max_length),
+        persistent_workers=bool(num_workers > 0),
+    )
+
+    enc_ctx = _load_encoder_from_ckpt(cfg, ckpt, role="ctx", device=device)
+    enc_tgt = _load_encoder_from_ckpt(cfg, ckpt, role="tgt", device=device)
+
+    mode = str(encoder_mode).lower()
+    if mode not in {"same_encoder", "context_target", "target_target"}:
+        raise ValueError(f"Unsupported encoder_mode: {encoder_mode}")
+
+    buggy_emb_all = []
+    fixed_emb_all = []
+    gidx_all = []
+
+    iterator = tqdm(dl, desc=f"[Extract rank{rank}]", leave=False) if is_main_process() else dl
+    for tok_buggy, tok_fixed, gidx in iterator:
+        tok_buggy = to_device(tok_buggy, device)
+        tok_fixed = to_device(tok_fixed, device)
+
+        if mode == "same_encoder":
+            buggy_seq = enc_ctx(tok_buggy["input_ids"], tok_buggy["attention_mask"])
+            fixed_seq = enc_ctx(tok_fixed["input_ids"], tok_fixed["attention_mask"])
+        elif mode == "context_target":
+            buggy_seq = enc_ctx(tok_buggy["input_ids"], tok_buggy["attention_mask"])
+            fixed_seq = enc_tgt(tok_fixed["input_ids"], tok_fixed["attention_mask"])
+        else:
+            buggy_seq = enc_tgt(tok_buggy["input_ids"], tok_buggy["attention_mask"])
+            fixed_seq = enc_tgt(tok_fixed["input_ids"], tok_fixed["attention_mask"])
+
+        buggy_emb_all.append(masked_mean_pool(buggy_seq, tok_buggy["attention_mask"]).cpu().float())
+        fixed_emb_all.append(masked_mean_pool(fixed_seq, tok_fixed["attention_mask"]).cpu().float())
+        gidx_all.append(gidx.cpu().long())
+
+    local_buggy = torch.cat(buggy_emb_all, dim=0).numpy() if buggy_emb_all else np.zeros((0, 1), dtype=np.float32)
+    local_fixed = torch.cat(fixed_emb_all, dim=0).numpy() if fixed_emb_all else np.zeros((0, 1), dtype=np.float32)
+    local_gidx = torch.cat(gidx_all, dim=0).numpy().astype(np.int64) if gidx_all else np.zeros((0,), dtype=np.int64)
+
+    if ddp_enabled():
+        gathered: list[Optional[dict[str, np.ndarray]]] = [None for _ in range(world)]
+        torch.distributed.all_gather_object(
+            gathered,
+            {"buggy": local_buggy, "fixed": local_fixed, "gidx": local_gidx},
+        )
+        buggy_parts = [item["buggy"] for item in gathered if item is not None]
+        fixed_parts = [item["fixed"] for item in gathered if item is not None]
+        gidx_parts = [item["gidx"] for item in gathered if item is not None]
+        full_buggy = np.concatenate(buggy_parts, axis=0) if buggy_parts else np.zeros((0, 1), dtype=np.float32)
+        full_fixed = np.concatenate(fixed_parts, axis=0) if fixed_parts else np.zeros((0, 1), dtype=np.float32)
+        full_gidx = np.concatenate(gidx_parts, axis=0).astype(np.int64) if gidx_parts else np.zeros((0,), dtype=np.int64)
+        order = np.argsort(full_gidx)
+        full_buggy = full_buggy[order]
+        full_fixed = full_fixed[order]
+        full_gidx = full_gidx[order]
+    else:
+        full_buggy = local_buggy
+        full_fixed = local_fixed
+        full_gidx = local_gidx
+
+    return LoadedSplitEmbeddings(
+        buggy_emb=full_buggy,
+        pred_emb=np.zeros((len(full_gidx), 1), dtype=np.float32),
+        tgt_emb=full_fixed,
+        global_indices=full_gidx,
+    )

--- a/JEPA_downstream/src/common/utils.py
+++ b/JEPA_downstream/src/common/utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+
+def ensure_dir(path: str | Path) -> None:
+    Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def save_json(obj: Any, path: str | Path) -> None:
+    path = Path(path)
+    ensure_dir(path.parent)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(obj, f, ensure_ascii=False, indent=2)
+
+
+def seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)

--- a/JEPA_downstream/src/edit_type/test.py
+++ b/JEPA_downstream/src/edit_type/test.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+import torch
+import torch.nn as nn
+from sklearn.metrics import f1_score
+from torch.utils.data import DataLoader, Dataset
+from tqdm.auto import tqdm
+
+from common import MultiLabelMLP, build_edit_type_feature, load_method_split_embeddings, load_multilabel_targets, load_online_split_embeddings, save_json
+
+
+class FeatureDataset(Dataset):
+    def __init__(self, features: np.ndarray, labels: np.ndarray | None = None) -> None:
+        self.features = np.asarray(features, dtype=np.float32)
+        self.labels = None if labels is None else np.asarray(labels, dtype=np.float32)
+
+    def __len__(self) -> int:
+        return len(self.features)
+
+    def __getitem__(self, idx: int):
+        x = torch.from_numpy(self.features[idx]).float()
+        if self.labels is None:
+            return x, int(idx)
+        y = torch.from_numpy(self.labels[idx]).float()
+        return x, y
+
+
+def make_dataloader(dataset: Dataset, batch_size: int, shuffle: bool, num_workers: int) -> DataLoader:
+    kwargs: Dict[str, Any] = {
+        "dataset": dataset,
+        "batch_size": batch_size,
+        "shuffle": shuffle,
+        "num_workers": num_workers,
+        "pin_memory": torch.cuda.is_available(),
+    }
+    if num_workers > 0:
+        kwargs["persistent_workers"] = True
+    return DataLoader(**kwargs)
+
+
+def compute_f1_metrics(y_true: np.ndarray, y_prob: np.ndarray, threshold: float = 0.5) -> Dict[str, float]:
+    y_pred = (y_prob >= threshold).astype(np.int32)
+    y_true = y_true.astype(np.int32)
+    micro = f1_score(y_true, y_pred, average="micro", zero_division=0)
+    macro = f1_score(y_true, y_pred, average="macro", zero_division=0)
+    return {"micro_f1": float(micro), "macro_f1": float(macro)}
+
+
+def load_split_features(
+    backend: str,
+    method: str,
+    split_dir: str,
+    embedding_view: str,
+    feature_mode: str,
+    file_kwargs: Dict[str, str],
+    online_kwargs: Dict[str, Any],
+):
+    if backend == "offline_pt":
+        loaded = load_method_split_embeddings(
+            split_dir,
+            method=method,
+            embedding_view=embedding_view,
+            **file_kwargs,
+        )
+        features = build_edit_type_feature(loaded.buggy_emb, loaded.tgt_emb, feature_mode)
+        return features, loaded.global_indices
+    if backend == "online_checkpoint":
+        loaded = load_online_split_embeddings(
+            checkpoint_path=str(online_kwargs["jepa_checkpoint"]),
+            config_path=str(online_kwargs["jepa_config"]),
+            encoder_mode=str(online_kwargs["encoder_mode"]),
+            indices_dir=str(online_kwargs["indices_dir"]),
+            indices_file=str(online_kwargs["indices_file"]),
+            global_target_dir=str(online_kwargs["global_target_dir"]),
+            global_target_file=str(online_kwargs["global_target_file"]),
+            hf_dataset_name=str(online_kwargs["hf_dataset_name"]),
+            hf_split=str(online_kwargs["hf_split"]),
+            hf_buggy_field=str(online_kwargs["hf_buggy_field"]),
+            hf_fixed_field=str(online_kwargs["hf_fixed_field"]),
+            max_len=int(online_kwargs["max_len"]),
+            batch_size=int(online_kwargs["extract_batch_size"]),
+            num_workers=int(online_kwargs["extract_num_workers"]),
+            device=online_kwargs["device"],
+        )
+        features = build_edit_type_feature(loaded.buggy_emb, loaded.tgt_emb, feature_mode)
+        return features, loaded.global_indices
+    raise ValueError(f"Unsupported backend: {backend}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Test edit-type multi-label classifier probe")
+    parser.add_argument("--checkpoint", type=str, required=True)
+    parser.add_argument("--split-dir", type=str, required=True)
+    parser.add_argument("--backend", type=str, default="", choices=["", "offline_pt", "online_checkpoint"])
+    parser.add_argument("--method", type=str, default="")
+    parser.add_argument("--embedding-view", type=str, default="", choices=["", "ctx", "tgt", "ctx_tgt"])
+    parser.add_argument("--feature-mode", type=str, default="")
+    parser.add_argument("--global-indices-key", type=str, default="global_indices")
+    parser.add_argument("--buggy-file-name", type=str, default="")
+    parser.add_argument("--buggy-key", type=str, default="")
+    parser.add_argument("--pred-file-name", type=str, default="")
+    parser.add_argument("--pred-key", type=str, default="")
+    parser.add_argument("--tgt-file-name", type=str, default="")
+    parser.add_argument("--tgt-key", type=str, default="")
+    parser.add_argument("--buggy-ctx-file-name", type=str, default="")
+    parser.add_argument("--buggy-ctx-key", type=str, default="")
+    parser.add_argument("--fixed-ctx-file-name", type=str, default="")
+    parser.add_argument("--fixed-ctx-key", type=str, default="")
+    parser.add_argument("--buggy-tgt-file-name", type=str, default="")
+    parser.add_argument("--buggy-tgt-key", type=str, default="")
+    parser.add_argument("--fixed-tgt-file-name", type=str, default="")
+    parser.add_argument("--fixed-tgt-key", type=str, default="")
+    parser.add_argument("--hf-dataset-name", type=str, default="ASSERT-KTH/RunBugRun-Final")
+    parser.add_argument("--hf-split", type=str, default="train")
+    parser.add_argument("--hf-label-field", type=str, default="labels")
+    parser.add_argument("--hf-buggy-field", type=str, default="")
+    parser.add_argument("--hf-fixed-field", type=str, default="")
+    parser.add_argument("--jepa-checkpoint", type=str, default="")
+    parser.add_argument("--jepa-config", type=str, default="")
+    parser.add_argument("--encoder-mode", type=str, default="same_encoder", choices=["same_encoder", "context_target", "target_target"])
+    parser.add_argument("--indices-dir", type=str, default="")
+    parser.add_argument("--global-target-dir", type=str, default="")
+    parser.add_argument("--global-target-file", type=str, default="global_target_indices.npy")
+    parser.add_argument("--indices-file", type=str, default="test_idx.npy")
+    parser.add_argument("--max-len", type=int, default=512)
+    parser.add_argument("--extract-batch-size", type=int, default=128)
+    parser.add_argument("--extract-num-workers", type=int, default=4)
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--output-json", type=str, required=True)
+    args = parser.parse_args()
+
+    ckpt = torch.load(args.checkpoint, map_location="cpu", weights_only=False)
+    backend = args.backend or ckpt.get("backend", "offline_pt")
+    method = args.method or ckpt.get("method", "e2")
+    embedding_view = args.embedding_view or ckpt.get("embedding_view", "ctx")
+    feature_mode = args.feature_mode or ckpt.get("feature_mode", "tgt_minus_buggy")
+    threshold = float(ckpt.get("threshold", 0.5))
+    file_kwargs = {
+        "global_indices_key": args.global_indices_key,
+        "buggy_file_name": args.buggy_file_name,
+        "buggy_key": args.buggy_key,
+        "pred_file_name": args.pred_file_name,
+        "pred_key": args.pred_key,
+        "tgt_file_name": args.tgt_file_name,
+        "tgt_key": args.tgt_key,
+        "buggy_ctx_file_name": args.buggy_ctx_file_name,
+        "buggy_ctx_key": args.buggy_ctx_key,
+        "fixed_ctx_file_name": args.fixed_ctx_file_name,
+        "fixed_ctx_key": args.fixed_ctx_key,
+        "buggy_tgt_file_name": args.buggy_tgt_file_name,
+        "buggy_tgt_key": args.buggy_tgt_key,
+        "fixed_tgt_file_name": args.fixed_tgt_file_name,
+        "fixed_tgt_key": args.fixed_tgt_key,
+    }
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    online_kwargs = {
+        "jepa_checkpoint": args.jepa_checkpoint,
+        "jepa_config": args.jepa_config,
+        "encoder_mode": args.encoder_mode,
+        "indices_dir": args.indices_dir,
+        "indices_file": args.indices_file,
+        "global_target_dir": args.global_target_dir,
+        "global_target_file": args.global_target_file,
+        "hf_dataset_name": args.hf_dataset_name,
+        "hf_split": args.hf_split,
+        "hf_buggy_field": args.hf_buggy_field,
+        "hf_fixed_field": args.hf_fixed_field,
+        "max_len": args.max_len,
+        "extract_batch_size": args.extract_batch_size,
+        "extract_num_workers": args.extract_num_workers,
+        "device": device,
+    }
+
+    features, global_indices = load_split_features(backend, method, args.split_dir, embedding_view, feature_mode, file_kwargs, online_kwargs)
+    labels, _, idx_to_label = load_multilabel_targets(
+        global_indices,
+        args.hf_dataset_name,
+        args.hf_split,
+        args.hf_label_field,
+        split_name=Path(args.split_dir).name,
+    )
+
+    ds = FeatureDataset(features, labels)
+    dl = make_dataloader(ds, args.batch_size, False, args.num_workers)
+
+    model = MultiLabelMLP(
+        ckpt["input_dim"],
+        ckpt["num_labels"],
+        hidden_dim=int(ckpt.get("hidden_dim", 512)),
+        dropout=float(ckpt.get("dropout", 0.3)),
+    )
+    model.load_state_dict(ckpt["model"])
+    model = model.to(device)
+    model.eval()
+    criterion = nn.BCEWithLogitsLoss()
+
+    running_loss = 0.0
+    total = 0
+    all_probs: List[np.ndarray] = []
+    all_targets: List[np.ndarray] = []
+
+    with torch.no_grad():
+        for x, y in tqdm(dl, desc="[Eval]", leave=False):
+            x = x.to(device, non_blocking=True)
+            y = y.to(device, non_blocking=True)
+            logits = model(x)
+            loss = criterion(logits, y)
+            probs = torch.sigmoid(logits)
+            bs = x.size(0)
+            total += bs
+            running_loss += loss.item() * bs
+            all_probs.append(probs.detach().cpu().numpy())
+            all_targets.append(y.detach().cpu().numpy())
+
+    y_prob = np.concatenate(all_probs, axis=0)
+    y_true = np.concatenate(all_targets, axis=0)
+    metrics = compute_f1_metrics(y_true, y_prob, threshold=threshold)
+    metrics["loss"] = float(running_loss / max(total, 1))
+
+    predictions: List[Dict[str, Any]] = []
+    for global_index, prob in zip(global_indices, y_prob):
+        pred_indices = np.where(prob >= threshold)[0].tolist()
+        predictions.append(
+            {
+                "global_index": int(global_index),
+                "predicted_label_indices": pred_indices,
+                "predicted_labels": [idx_to_label[i] for i in pred_indices],
+                "probabilities": prob.tolist(),
+            }
+        )
+
+    output = {
+        "backend": backend,
+        "method": method,
+        "embedding_view": embedding_view,
+        "feature_mode": feature_mode,
+        "metrics": metrics,
+        "predictions": predictions,
+    }
+    save_json(output, args.output_json)
+    print(json.dumps(output["metrics"], ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/JEPA_downstream/src/edit_type/train.py
+++ b/JEPA_downstream/src/edit_type/train.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+from sklearn.metrics import f1_score
+from torch.utils.data import DataLoader, Dataset
+from tqdm.auto import tqdm
+
+from common import (
+    EDIT_TYPE_FEATURE_MODES,
+    MultiLabelMLP,
+    build_edit_type_feature,
+    infer_edit_type_input_dim,
+    load_method_split_embeddings,
+    load_multilabel_targets,
+    load_online_split_embeddings,
+    save_json,
+    seed_everything,
+)
+
+
+try:
+    import wandb  # type: ignore
+except Exception:
+    wandb = None
+
+
+class FeatureDataset(Dataset):
+    def __init__(self, features: np.ndarray, labels: Optional[np.ndarray] = None) -> None:
+        self.features = np.asarray(features, dtype=np.float32)
+        self.labels = None if labels is None else np.asarray(labels, dtype=np.float32)
+        if self.labels is not None and len(self.features) != len(self.labels):
+            raise ValueError("features and labels must have the same length")
+
+    def __len__(self) -> int:
+        return len(self.features)
+
+    def __getitem__(self, idx: int):
+        x = torch.from_numpy(self.features[idx]).float()
+        if self.labels is None:
+            return x, int(idx)
+        y = torch.from_numpy(self.labels[idx]).float()
+        return x, y
+
+
+def make_dataloader(dataset: Dataset, batch_size: int, shuffle: bool, num_workers: int) -> DataLoader:
+    kwargs: Dict[str, Any] = {
+        "dataset": dataset,
+        "batch_size": batch_size,
+        "shuffle": shuffle,
+        "num_workers": num_workers,
+        "pin_memory": torch.cuda.is_available(),
+    }
+    if num_workers > 0:
+        kwargs["persistent_workers"] = True
+    return DataLoader(**kwargs)
+
+
+def compute_f1_metrics(y_true: np.ndarray, y_prob: np.ndarray, threshold: float = 0.5) -> Dict[str, float]:
+    y_pred = (y_prob >= threshold).astype(np.int32)
+    y_true = y_true.astype(np.int32)
+    micro = f1_score(y_true, y_pred, average="micro", zero_division=0)
+    macro = f1_score(y_true, y_pred, average="macro", zero_division=0)
+    return {"micro_f1": float(micro), "macro_f1": float(macro)}
+
+
+def load_split_features(
+    backend: str,
+    method: str,
+    split_dir: str,
+    embedding_view: str,
+    feature_mode: str,
+    file_kwargs: Dict[str, str],
+    online_kwargs: Dict[str, Any],
+) -> Tuple[np.ndarray, np.ndarray]:
+    if backend == "offline_pt":
+        loaded = load_method_split_embeddings(
+            split_dir,
+            method=method,
+            embedding_view=embedding_view,
+            **file_kwargs,
+        )
+        features = build_edit_type_feature(loaded.buggy_emb, loaded.tgt_emb, feature_mode)
+        return features, loaded.global_indices
+    if backend == "online_checkpoint":
+        loaded = load_online_split_embeddings(
+            checkpoint_path=str(online_kwargs["jepa_checkpoint"]),
+            config_path=str(online_kwargs["jepa_config"]),
+            encoder_mode=str(online_kwargs["encoder_mode"]),
+            indices_dir=str(online_kwargs["indices_dir"]),
+            indices_file=str(online_kwargs["indices_file_by_split"][split_dir]),
+            global_target_dir=str(online_kwargs["global_target_dir"]),
+            global_target_file=str(online_kwargs["global_target_file"]),
+            hf_dataset_name=str(online_kwargs["hf_dataset_name"]),
+            hf_split=str(online_kwargs["hf_split"]),
+            hf_buggy_field=str(online_kwargs["hf_buggy_field"]),
+            hf_fixed_field=str(online_kwargs["hf_fixed_field"]),
+            max_len=int(online_kwargs["max_len"]),
+            batch_size=int(online_kwargs["extract_batch_size"]),
+            num_workers=int(online_kwargs["extract_num_workers"]),
+            device=online_kwargs["device"],
+        )
+        features = build_edit_type_feature(loaded.buggy_emb, loaded.tgt_emb, feature_mode)
+        return features, loaded.global_indices
+    raise ValueError(f"Unsupported backend: {backend}")
+
+
+def evaluate(
+    model: nn.Module,
+    dataloader: DataLoader,
+    criterion: nn.Module,
+    device: torch.device,
+    threshold: float,
+    split_name: str,
+) -> Dict[str, float]:
+    model.eval()
+    running_loss = 0.0
+    total = 0
+    all_probs: List[np.ndarray] = []
+    all_targets: List[np.ndarray] = []
+
+    with torch.no_grad():
+        for x, y in tqdm(dataloader, desc=f"[{split_name}]", leave=False):
+            x = x.to(device, non_blocking=True)
+            y = y.to(device, non_blocking=True)
+            logits = model(x)
+            loss = criterion(logits, y)
+            probs = torch.sigmoid(logits)
+
+            bs = x.size(0)
+            total += bs
+            running_loss += loss.item() * bs
+            all_probs.append(probs.detach().cpu().numpy())
+            all_targets.append(y.detach().cpu().numpy())
+
+    y_prob = np.concatenate(all_probs, axis=0) if all_probs else np.zeros((0, 0), dtype=np.float32)
+    y_true = np.concatenate(all_targets, axis=0) if all_targets else np.zeros((0, 0), dtype=np.float32)
+    metrics = compute_f1_metrics(y_true, y_prob, threshold=threshold)
+    metrics["loss"] = float(running_loss / max(total, 1))
+    return metrics
+
+
+def build_predictions(
+    model: nn.Module,
+    features: np.ndarray,
+    global_indices: np.ndarray,
+    idx_to_label: Dict[int, str],
+    batch_size: int,
+    device: torch.device,
+    threshold: float,
+) -> List[Dict[str, Any]]:
+    model.eval()
+    ds = FeatureDataset(features, labels=None)
+    dl = make_dataloader(ds, batch_size=batch_size, shuffle=False, num_workers=0)
+    outputs: List[Dict[str, Any]] = []
+
+    cursor = 0
+    with torch.no_grad():
+        for x, _ in tqdm(dl, desc="[Predict]", leave=False):
+            x = x.to(device, non_blocking=True)
+            probs = torch.sigmoid(model(x)).detach().cpu().numpy()
+            bs = probs.shape[0]
+            for global_index, prob in zip(global_indices[cursor:cursor + bs], probs):
+                pred_indices = np.where(prob >= threshold)[0].tolist()
+                outputs.append(
+                    {
+                        "global_index": int(global_index),
+                        "predicted_label_indices": pred_indices,
+                        "predicted_labels": [idx_to_label[i] for i in pred_indices],
+                        "probabilities": prob.tolist(),
+                    }
+                )
+            cursor += bs
+    return outputs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train edit-type multi-label classifier probe")
+    parser.add_argument("--backend", type=str, default="offline_pt", choices=["offline_pt", "online_checkpoint"])
+    parser.add_argument("--method", type=str, default="e2", choices=["e1", "e2", "seq_emb"])
+    parser.add_argument("--train-dir", type=str, required=True)
+    parser.add_argument("--val-dir", type=str, required=True)
+    parser.add_argument("--test-dir", type=str, required=True)
+    parser.add_argument("--embedding-view", type=str, default="ctx", choices=["ctx", "tgt", "ctx_tgt"])
+    parser.add_argument("--feature-mode", type=str, default="tgt_minus_buggy", choices=list(EDIT_TYPE_FEATURE_MODES))
+    parser.add_argument("--global-indices-key", type=str, default="global_indices")
+    parser.add_argument("--buggy-file-name", type=str, default="")
+    parser.add_argument("--buggy-key", type=str, default="")
+    parser.add_argument("--pred-file-name", type=str, default="")
+    parser.add_argument("--pred-key", type=str, default="")
+    parser.add_argument("--tgt-file-name", type=str, default="")
+    parser.add_argument("--tgt-key", type=str, default="")
+    parser.add_argument("--buggy-ctx-file-name", type=str, default="")
+    parser.add_argument("--buggy-ctx-key", type=str, default="")
+    parser.add_argument("--fixed-ctx-file-name", type=str, default="")
+    parser.add_argument("--fixed-ctx-key", type=str, default="")
+    parser.add_argument("--buggy-tgt-file-name", type=str, default="")
+    parser.add_argument("--buggy-tgt-key", type=str, default="")
+    parser.add_argument("--fixed-tgt-file-name", type=str, default="")
+    parser.add_argument("--fixed-tgt-key", type=str, default="")
+    parser.add_argument("--hf-dataset-name", type=str, default="ASSERT-KTH/RunBugRun-Final")
+    parser.add_argument("--hf-split", type=str, default="train")
+    parser.add_argument("--hf-label-field", type=str, default="labels")
+    parser.add_argument("--hf-buggy-field", type=str, default="")
+    parser.add_argument("--hf-fixed-field", type=str, default="")
+    parser.add_argument("--jepa-checkpoint", type=str, default="")
+    parser.add_argument("--jepa-config", type=str, default="")
+    parser.add_argument("--encoder-mode", type=str, default="same_encoder", choices=["same_encoder", "context_target", "target_target"])
+    parser.add_argument("--indices-dir", type=str, default="")
+    parser.add_argument("--global-target-dir", type=str, default="")
+    parser.add_argument("--global-target-file", type=str, default="global_target_indices.npy")
+    parser.add_argument("--train-indices", type=str, default="train_idx.npy")
+    parser.add_argument("--val-indices", type=str, default="val_idx.npy")
+    parser.add_argument("--test-indices", type=str, default="test_idx.npy")
+    parser.add_argument("--max-len", type=int, default=512)
+    parser.add_argument("--extract-batch-size", type=int, default=128)
+    parser.add_argument("--extract-num-workers", type=int, default=4)
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--epochs", type=int, default=20)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--hidden-dim", type=int, default=512)
+    parser.add_argument("--dropout", type=float, default=0.3)
+    parser.add_argument("--threshold", type=float, default=0.5)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-dir", type=str, required=True)
+    parser.add_argument("--use-wandb", type=int, default=0)
+    parser.add_argument("--wandb-project", type=str, default="CodeRepair_JEPA_downstream")
+    parser.add_argument("--wandb-entity", type=str, default="assert-kth")
+    parser.add_argument("--wandb-run-name", type=str, default="")
+    parser.add_argument("--wandb-group", type=str, default="edit_type")
+    parser.add_argument("--wandb-id", type=str, default="")
+    args = parser.parse_args()
+
+    Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+    seed_everything(args.seed)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    file_kwargs = {
+        "global_indices_key": args.global_indices_key,
+        "buggy_file_name": args.buggy_file_name,
+        "buggy_key": args.buggy_key,
+        "pred_file_name": args.pred_file_name,
+        "pred_key": args.pred_key,
+        "tgt_file_name": args.tgt_file_name,
+        "tgt_key": args.tgt_key,
+        "buggy_ctx_file_name": args.buggy_ctx_file_name,
+        "buggy_ctx_key": args.buggy_ctx_key,
+        "fixed_ctx_file_name": args.fixed_ctx_file_name,
+        "fixed_ctx_key": args.fixed_ctx_key,
+        "buggy_tgt_file_name": args.buggy_tgt_file_name,
+        "buggy_tgt_key": args.buggy_tgt_key,
+        "fixed_tgt_file_name": args.fixed_tgt_file_name,
+        "fixed_tgt_key": args.fixed_tgt_key,
+    }
+    online_kwargs = {
+        "jepa_checkpoint": args.jepa_checkpoint,
+        "jepa_config": args.jepa_config,
+        "encoder_mode": args.encoder_mode,
+        "indices_dir": args.indices_dir,
+        "global_target_dir": args.global_target_dir,
+        "global_target_file": args.global_target_file,
+        "hf_dataset_name": args.hf_dataset_name,
+        "hf_split": args.hf_split,
+        "hf_buggy_field": args.hf_buggy_field,
+        "hf_fixed_field": args.hf_fixed_field,
+        "max_len": args.max_len,
+        "extract_batch_size": args.extract_batch_size,
+        "extract_num_workers": args.extract_num_workers,
+        "device": device,
+        "indices_file_by_split": {
+            args.train_dir: args.train_indices,
+            args.val_dir: args.val_indices,
+            args.test_dir: args.test_indices,
+        },
+    }
+
+    train_x, train_global = load_split_features(args.backend, args.method, args.train_dir, args.embedding_view, args.feature_mode, file_kwargs, online_kwargs)
+    val_x, val_global = load_split_features(args.backend, args.method, args.val_dir, args.embedding_view, args.feature_mode, file_kwargs, online_kwargs)
+    test_x, test_global = load_split_features(args.backend, args.method, args.test_dir, args.embedding_view, args.feature_mode, file_kwargs, online_kwargs)
+
+    y_train, label_to_idx, idx_to_label = load_multilabel_targets(
+        train_global, args.hf_dataset_name, args.hf_split, args.hf_label_field, "train"
+    )
+    y_val, _, _ = load_multilabel_targets(
+        val_global, args.hf_dataset_name, args.hf_split, args.hf_label_field, "val", label_to_idx=label_to_idx
+    )
+    y_test, _, _ = load_multilabel_targets(
+        test_global, args.hf_dataset_name, args.hf_split, args.hf_label_field, "test", label_to_idx=label_to_idx
+    )
+
+    save_json(
+        {
+            "label_to_idx": label_to_idx,
+            "idx_to_label": {str(k): v for k, v in idx_to_label.items()},
+            "num_labels": len(label_to_idx),
+            "backend": args.backend,
+            "method": args.method,
+            "embedding_view": args.embedding_view,
+            "feature_mode": args.feature_mode,
+        },
+        Path(args.output_dir) / "label_map.json",
+    )
+
+    train_ds = FeatureDataset(train_x, y_train)
+    val_ds = FeatureDataset(val_x, y_val)
+    test_ds = FeatureDataset(test_x, y_test)
+
+    train_dl = make_dataloader(train_ds, args.batch_size, True, args.num_workers)
+    val_dl = make_dataloader(val_ds, args.batch_size, False, args.num_workers)
+    test_dl = make_dataloader(test_ds, args.batch_size, False, args.num_workers)
+
+    input_dim = infer_edit_type_input_dim(args.feature_mode, train_x.shape[1])
+    model = MultiLabelMLP(input_dim, len(label_to_idx), hidden_dim=args.hidden_dim, dropout=args.dropout).to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+    criterion = nn.BCEWithLogitsLoss()
+
+    best_val_micro = -1.0
+    best_epoch = -1
+    history: List[Dict[str, Any]] = []
+    best_ckpt_path = Path(args.output_dir) / "best_model.pt"
+    last_ckpt_path = Path(args.output_dir) / "last_model.pt"
+
+    if args.use_wandb and wandb is not None:
+        wandb.init(
+            project=args.wandb_project or None,
+            entity=args.wandb_entity or None,
+            name=args.wandb_run_name or None,
+            group=args.wandb_group or None,
+            id=args.wandb_id or None,
+            resume="allow" if args.wandb_id else None,
+            config={
+                "backend": args.backend,
+                "method": args.method,
+                "embedding_view": args.embedding_view,
+                "feature_mode": args.feature_mode,
+                "batch_size": args.batch_size,
+                "epochs": args.epochs,
+                "lr": args.lr,
+                "hidden_dim": args.hidden_dim,
+                "dropout": args.dropout,
+            },
+        )
+
+    for epoch in range(1, args.epochs + 1):
+        model.train()
+        running_loss = 0.0
+        total = 0
+        for x, y in tqdm(train_dl, desc=f"[Train {epoch}/{args.epochs}]", leave=False):
+            x = x.to(device, non_blocking=True)
+            y = y.to(device, non_blocking=True)
+
+            optimizer.zero_grad(set_to_none=True)
+            logits = model(x)
+            loss = criterion(logits, y)
+            loss.backward()
+            optimizer.step()
+
+            bs = x.size(0)
+            total += bs
+            running_loss += loss.item() * bs
+
+        train_loss = float(running_loss / max(total, 1))
+        val_metrics = evaluate(model, val_dl, criterion, device, args.threshold, "Val")
+
+        record = {
+            "epoch": epoch,
+            "train_loss": train_loss,
+            "val_loss": val_metrics["loss"],
+            "val_micro_f1": val_metrics["micro_f1"],
+            "val_macro_f1": val_metrics["macro_f1"],
+        }
+        history.append(record)
+
+        print(
+            f"Epoch {epoch:03d} | train={train_loss:.4f} "
+            f"val_micro={val_metrics['micro_f1']:.4f} val_macro={val_metrics['macro_f1']:.4f}"
+        )
+
+        if args.use_wandb and wandb is not None and wandb.run is not None:
+            wandb.log(
+                {
+                    "epoch": epoch,
+                    "train/loss": train_loss,
+                    "val/loss": val_metrics["loss"],
+                    "val/micro_f1": val_metrics["micro_f1"],
+                    "val/macro_f1": val_metrics["macro_f1"],
+                },
+                step=epoch,
+            )
+
+        ckpt = {
+            "model": model.state_dict(),
+            "input_dim": input_dim,
+            "num_labels": len(label_to_idx),
+            "threshold": args.threshold,
+            "epoch": epoch,
+            "backend": args.backend,
+            "method": args.method,
+            "embedding_view": args.embedding_view,
+            "feature_mode": args.feature_mode,
+            "hidden_dim": args.hidden_dim,
+            "dropout": args.dropout,
+        }
+        torch.save(ckpt, last_ckpt_path)
+
+        if val_metrics["micro_f1"] > best_val_micro:
+            best_val_micro = val_metrics["micro_f1"]
+            best_epoch = epoch
+            ckpt["best_val_micro_f1"] = best_val_micro
+            torch.save(ckpt, best_ckpt_path)
+
+    save_json(history, Path(args.output_dir) / "history.json")
+
+    best_ckpt = torch.load(best_ckpt_path, map_location="cpu", weights_only=False)
+    best_model = MultiLabelMLP(
+        best_ckpt["input_dim"],
+        best_ckpt["num_labels"],
+        hidden_dim=int(best_ckpt.get("hidden_dim", args.hidden_dim)),
+        dropout=float(best_ckpt.get("dropout", args.dropout)),
+    )
+    best_model.load_state_dict(best_ckpt["model"])
+    best_model = best_model.to(device)
+
+    val_metrics = evaluate(best_model, val_dl, criterion, device, args.threshold, "Val-best")
+    test_metrics = evaluate(best_model, test_dl, criterion, device, args.threshold, "Test-best")
+    test_predictions = build_predictions(
+        best_model,
+        test_x,
+        test_global,
+        idx_to_label,
+        args.batch_size,
+        device,
+        args.threshold,
+    )
+
+    final_metrics = {
+        "best_val_micro_f1": best_val_micro,
+        "best_epoch": best_epoch,
+        "val": val_metrics,
+        "test": test_metrics,
+    }
+    save_json(final_metrics, Path(args.output_dir) / "final_metrics.json")
+    save_json(test_predictions, Path(args.output_dir) / "test_predictions.json")
+
+    if args.use_wandb and wandb is not None and wandb.run is not None:
+        wandb.run.summary["best_val_micro_f1"] = best_val_micro
+        wandb.run.summary["best_epoch"] = best_epoch
+        wandb.run.summary["test_micro_f1"] = test_metrics["micro_f1"]
+        wandb.run.summary["test_macro_f1"] = test_metrics["macro_f1"]
+        wandb.finish()
+
+    print(json.dumps(final_metrics, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds two downstream evaluation tasks for learned code embeddings:

- 'bug_detection': binary classification of buggy vs fixed code
- 'edit_type': multi-label classification of repair types

The implementation supports both offline embeddings and online extraction from JEPA checkpoints, so the same downstream probes can be used across different embedding methods.